### PR TITLE
Parallelize by chunk instead of querying twice.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
         with:
           manifest-path: pyproject.toml
       - name: Run Tests
-        run: pixi run --environment ${{ matrix.pixi-environment }} test
+        run: |
+          pixi run --environment ${{ matrix.pixi-environment }} test &&
+          pixi run --environment ${{ matrix.pixi-environment }} test-single-thread &&
+          pixi run --environment ${{ matrix.pixi-environment }} test-jit
 
   build:
     runs-on: ubuntu-latest

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,35 @@
 CellTree2d
-----------
+==========
 
 .. automodule:: numba_celltree
     :members:
     :imported-members:
     :undoc-members:
     :show-inheritance:
+
+Changelog
+=========
+
+Unreleased
+----------
+
+Fixed
+~~~~~
+
+- :meth:`CellTree2d.intersect_edges` could hang indefinitely due to a while
+  loop with faulty logic in
+  :func:`numba_celltree.algorithms.cohen_sutherland_line_box_clip`. This issue
+  seems to appears when an edge vertex lies exactly on top of a bounding box
+  vertex of the celltree. The logic has been updated and this has been fixed.
+
+Changed
+~~~~~~~
+
+- The parallellization strategy of :meth:`CellTree2d.locate_boxes`,
+  :meth:`CellTree2d.intersect_boxes`, :meth:`CellTree2d.locate_faces`,
+  :meth:`CellTree2d.intersect_faces`, and :meth:`CellTree2d.intersect_edges`
+  has been changed. Instead of querying twice -- once to count, then
+  pre-allocate, then again to store result values -- has been replaced by
+  manual chunking of input and dynamic allocation per chunk (thread). This
+  should result in a net ~30% performance gain in most cases.
+

--- a/numba_celltree/algorithms/cohen_sutherland.py
+++ b/numba_celltree/algorithms/cohen_sutherland.py
@@ -92,4 +92,10 @@ def cohen_sutherland_line_box_clip(a: Point, b: Point, box: Box) -> Tuple[Point,
             b = Point(x, y)
             k2 = get_clip(b, box)
 
+        # Recompute (dx, dy) with new points.
+        dx = b.x - a.x
+        dy = b.y - a.y
+        if dx == 0.0 and dy == 0.0:
+            return NO_INTERSECTION
+
     return True, a, b

--- a/numba_celltree/algorithms/cohen_sutherland.py
+++ b/numba_celltree/algorithms/cohen_sutherland.py
@@ -43,9 +43,8 @@ def cohen_sutherland_line_box_clip(a: Point, b: Point, box: Box) -> Tuple[Point,
     defined by a.x, a.y (start point) and b.x, b.y (end point) will be
     clipped.
 
-    If the line does not intersect with the rectangular clipping area,
-    four None values will be returned as tuple. Otherwise a tuple of the
-    clipped line points will be returned in the form (cx1, ca.y, cb.x, cb.y).
+    If the line does not intersect with the rectangular clipping area, a
+    boolean False and NaN-valued points will be returned.
     """
     NO_INTERSECTION = False, Point(np.nan, np.nan), Point(np.nan, np.nan)
     dx = b.x - a.x
@@ -59,6 +58,7 @@ def cohen_sutherland_line_box_clip(a: Point, b: Point, box: Box) -> Tuple[Point,
 
     # examine non-trivially outside points
     # bitwise OR |
+    # TODO: Figure out maximum number of iterations and replace by a for loop.
     while (k1 | k2) != INSIDE:
         # if both points are inside box (0000),
         # ACCEPT trivial whole line in box, exit.

--- a/numba_celltree/algorithms/liang_barsky.py
+++ b/numba_celltree/algorithms/liang_barsky.py
@@ -54,6 +54,11 @@ def liang_barsky_line_box_clip(
                 elif t < t1:
                     t1 = t
 
+    # TODO: Can this check be set as the first thing in the for loop for early
+    # exits?
+    if t0 == t1:
+        return NO_INTERSECTION
+
     c = Point(a.x + t0 * dx, a.y + t0 * dy)
     d = Point(a.x + t1 * dx, a.y + t1 * dy)
     return True, c, d

--- a/numba_celltree/celltree.py
+++ b/numba_celltree/celltree.py
@@ -330,7 +330,8 @@ class CellTree2d:
             ``np.linalg.norm(intersections[:, 1] - intersections[:, 0], axis=1)``.
         """
         edge_coords = cast_edges(edge_coords)
-        return locate_edges(edge_coords, self.celltree_data)
+        n_chunks = nb.get_num_threads()
+        return locate_edges(edge_coords, self.celltree_data, n_chunks)
 
     def compute_barycentric_weights(
         self,

--- a/numba_celltree/celltree.py
+++ b/numba_celltree/celltree.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+import numba as nb
 import numpy as np
 
 from numba_celltree.algorithms import (
@@ -181,7 +182,8 @@ class CellTree2d:
             Indices of the face.
         """
         bbox_coords = cast_bboxes(bbox_coords)
-        return locate_boxes(bbox_coords, self.celltree_data)
+        n_chunks = nb.get_num_threads()
+        return locate_boxes(bbox_coords, self.celltree_data, n_chunks)
 
     def intersect_boxes(
         self, bbox_coords: FloatArray
@@ -205,7 +207,8 @@ class CellTree2d:
             Area of intersection between the two intersecting faces.
         """
         bbox_coords = cast_bboxes(bbox_coords)
-        i, j = locate_boxes(bbox_coords, self.celltree_data)
+        n_chunks = nb.get_num_threads()
+        i, j = locate_boxes(bbox_coords, self.celltree_data, n_chunks)
         area = box_area_of_intersection(
             bbox_coords=bbox_coords,
             vertices=self.vertices,
@@ -246,7 +249,10 @@ class CellTree2d:
         """
         counter_clockwise(vertices, faces)
         bbox_coords = build_bboxes(faces, vertices)
-        shortlist_i, shortlist_j = locate_boxes(bbox_coords, self.celltree_data)
+        n_chunks = nb.get_num_threads()
+        shortlist_i, shortlist_j = locate_boxes(
+            bbox_coords, self.celltree_data, n_chunks
+        )
         intersects = polygons_intersect(
             vertices_a=vertices,
             vertices_b=self.vertices,

--- a/numba_celltree/constants.py
+++ b/numba_celltree/constants.py
@@ -143,7 +143,7 @@ FILL_VALUE = -1
 # (int(math.ceil(math.log(MAX_N_FACE, 2))) + 1)
 # This is only true for relatively balanced trees. MAX_N_FACE = int(2e9)
 # results in required stack of 32.
-INITIAL_TREE_DEPTH = 32
+INITIAL_STACK_LENGTH = 32
 # Floating point slack
 TOLERANCE_ON_EDGE = 1e-9
 

--- a/numba_celltree/creation.py
+++ b/numba_celltree/creation.py
@@ -18,7 +18,11 @@ from numba_celltree.constants import (
     NodeDType,
 )
 from numba_celltree.geometry_utils import build_bboxes
-from numba_celltree.utils import allocate_stack, pop, push
+from numba_celltree.utils import (
+    allocate_double_stack,
+    pop_both,
+    push_both,
+)
 
 
 @nb.njit(inline="always")
@@ -227,20 +231,6 @@ def pessimistic_n_nodes(n_polys: int):
     return n_nodes + 1
 
 
-@nb.njit(inline="always")
-def push_both(root_stack, dim_stack, root, dim, size):
-    root_stack, size_root = push(root_stack, root, size)
-    dim_stack, _ = push(dim_stack, dim, size)
-    return root_stack, dim_stack, size_root
-
-
-@nb.njit(inline="always")
-def pop_both(root_stack, dim_stack, size):
-    root, size_root = pop(root_stack, size)
-    dim, _ = pop(dim_stack, size)
-    return root, dim, size_root
-
-
 @nb.njit(cache=True)
 def build(
     nodes: NodeArray,
@@ -251,15 +241,14 @@ def build(
     cells_per_leaf: int,
 ):
     # Cannot compile ahead of time with Numba and recursion
-    # Just use a stack based approach instead
-    root_stack = allocate_stack()
-    dim_stack = allocate_stack()
-    root_stack[0] = 0
-    dim_stack[0] = 0
+    # Just use a stack based approach instead; store root and dim values.
+    stack = allocate_double_stack()
+    stack[0, 0] = 0
+    stack[0, 1] = 0
     size = 1
 
     while size > 0:
-        root_index, dim, size = pop_both(root_stack, dim_stack, size)
+        root_index, dim, size = pop_both(stack, size)
 
         dim_flag = dim
         if dim < 0:
@@ -303,7 +292,7 @@ def build(
                     0,  # size
                 )
             )
-        # NOTA BENE: do not change the default size (0) given to the bucket here
+        # NOTE: do not change the default size (0) given to the bucket here
         # it is used to detect empty buckets later on.
 
         # Now that the buckets are setup, sort them
@@ -361,9 +350,7 @@ def build(
                 if dim_flag >= 0:
                     dim_flag = (not dim) - 2
                     nodes[root_index]["dim"] = not root.dim
-                    root_stack, dim_stack, size = push_both(
-                        root_stack, dim_stack, root_index, dim_flag, size
-                    )
+                    stack, size = push_both(stack, root_index, dim_flag, size)
                 else:  # Already split once, convert to leaf.
                     nodes[root_index]["Lmax"] = -1
                     nodes[root_index]["Rmin"] = -1
@@ -389,12 +376,8 @@ def build(
         node_index = push_node(nodes, left_child, node_index)
         node_index = push_node(nodes, right_child, node_index)
 
-        root_stack, dim_stack, size = push_both(
-            root_stack, dim_stack, child_ind + 1, right_child.dim, size
-        )
-        root_stack, dim_stack, size = push_both(
-            root_stack, dim_stack, child_ind, left_child.dim, size
-        )
+        stack, size = push_both(stack, child_ind + 1, right_child.dim, size)
+        stack, size = push_both(stack, child_ind, left_child.dim, size)
 
     return node_index
 

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -350,7 +350,7 @@ def locate_edges_helper(
     # Ensure the initial indices array isn't too small.
     n = max(n_edge, 256)
     indices = np.empty((n, 2), dtype=IntDType)
-    xy = np.empty((n, 2, 2), dtype=FloatDType)
+    xy = np.zeros((n, 2, 2), dtype=FloatDType)
 
     total_count = 0
     indices_size = 0
@@ -391,7 +391,7 @@ def locate_edges(box_coords: FloatArray, tree: CellTreeData, n_chunks: int):
         )
 
     total_size = sum(counts)
-    xy = np.empty((total_size, 2, 2), dtype=FloatDType)
+    xy = np.zeros((total_size, 2, 2), dtype=FloatDType)
     start = 0
     for i, size in enumerate(counts):
         end = start + size

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -280,10 +280,10 @@ def locate_edge(
                             return -1, indices_size
                         indices[indices_size, 0] = index
                         indices[indices_size, 1] = bbox_index
-                        intersections[count, 0, 0] = c.x
-                        intersections[count, 0, 1] = c.y
-                        intersections[count, 1, 0] = d.x
-                        intersections[count, 1, 1] = d.y
+                        intersections[indices_size, 0, 0] = c.x
+                        intersections[indices_size, 0, 1] = c.y
+                        intersections[indices_size, 1, 0] = d.x
+                        intersections[indices_size, 1, 1] = d.y
                         indices_size += 1
                         count += 1
             continue

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numba as nb
 import numpy as np
 
@@ -25,7 +27,32 @@ from numba_celltree.geometry_utils import (
     point_in_polygon_or_on_edge,
     to_vector,
 )
-from numba_celltree.utils import allocate_polygon, allocate_stack, pop, push
+from numba_celltree.utils import (
+    allocate_polygon,
+    allocate_stack,
+    allocate_triple_stack,
+    grow,
+    pop,
+    pop_triple,
+    push,
+    push_triple,
+)
+
+
+@nb.njit(inline="always")
+def concatenate_indices(
+    indices: IntArray, counts: IntArray
+) -> Tuple[IntArray, IntArray]:
+    total_size = sum(counts)
+    ii = np.empty(total_size, dtype=IntDType)
+    jj = np.empty(total_size, dtype=IntDType)
+    start = 0
+    for i, size in enumerate(counts):
+        end = start + size
+        ii[start:end] = indices[i][:size, 0]
+        jj[start:end] = indices[i][:size, 1]
+        start = end
+    return ii, jj
 
 
 # Inlining saves about 15% runtime
@@ -90,14 +117,33 @@ def locate_points(
 
 
 @nb.njit(inline="always")
-def locate_box(box: Box, tree: CellTreeData, indices: IntArray, store_indices: bool):
+def locate_box(
+    box: Box, tree: CellTreeData, indices: IntArray, indices_size: int, index: int
+) -> Tuple[int, int]:
+    """
+    Search the tree for a single axis-aligned box.
+
+    Parameters
+    ----------
+    box: Box named tuple
+    tree: CellTreeData
+    indices: IntArray
+        Array for results. Contains ``index`` of the box we're searching for
+        the first column, and the index of the box in the celltree (if any) in
+        the second.
+    indices_size: int
+        Current number of filled in values in ``indices``.
+    index: int
+        Current index of the box we're searching.
+    """
     tree_bbox = as_box(tree.bbox)
     if not boxes_intersect(box, tree_bbox):
-        return 0
+        return 0, indices_size
     stack = allocate_stack()
     stack[0] = 0
     size = 1
     count = 0
+    length = len(indices)
 
     while size > 0:
         node_index, size = pop(stack, size)
@@ -110,8 +156,15 @@ def locate_box(box: Box, tree: CellTreeData, indices: IntArray, store_indices: b
                 # As a named tuple: saves about 15% runtime
                 leaf_box = as_box(tree.bb_coords[bbox_index])
                 if boxes_intersect(box, leaf_box):
-                    if store_indices:
-                        indices[count] = bbox_index
+                    # Exit if we need to re-allocate the array. Exiting instead
+                    # of drawing the re-allocation logic in here makes a
+                    # significant runtime difference; seems like numba can
+                    # optimize this form better.
+                    if indices_size >= length:
+                        return -1, indices_size
+                    indices[indices_size, 0] = index
+                    indices[indices_size, 1] = bbox_index
+                    indices_size += 1
                     count += 1
         else:
             dim = 1 if node["dim"] else 0
@@ -130,51 +183,52 @@ def locate_box(box: Box, tree: CellTreeData, indices: IntArray, store_indices: b
             elif right:
                 stack, size = push(stack, right_child, size)
 
-    return count
+    return count, indices_size
 
 
-@nb.njit(parallel=PARALLEL, cache=True)
-def locate_boxes(
+@nb.njit(cache=True)
+def locate_boxes_helper(
     box_coords: FloatArray,
     tree: CellTreeData,
-):
-    # Numba does not support a concurrent list or bag like stucture:
-    # https://github.com/numba/numba/issues/5878
-    # (Standard lists are not thread safe.)
-    # To support parallel execution, we're stuck with numpy arrays therefore.
-    # Since we don't know the number of contained bounding boxes, we traverse
-    # the tree twice: first to count, then allocate, then another time to
-    # actually store the indices.
-    # The cost of traversing twice is roughly a factor two. Since many
-    # computers can parallellize over more than two threads, counting first --
-    # which enables parallelization -- should still result in a net speed up.
-    n_box = box_coords.shape[0]
-    counts = np.empty(n_box + 1, dtype=IntDType)
-    dummy = np.empty((0,), dtype=IntDType)
-    counts[0] = 0
-    # First run a count so we can allocate afterwards
-    for i in nb.prange(n_box):  # pylint: disable=not-an-iterable
-        box = as_box(box_coords[i])
-        counts[i + 1] = locate_box(box, tree, dummy, False)
+    offset: int,
+) -> IntArray:
+    n_box = len(box_coords)
+    # Ensure the initial indices array isn't too small.
+    indices = np.empty((max(n_box, 256), 2), dtype=IntDType)
+    total_count = 0
+    indices_size = 0
+    for box_index in range(n_box):
+        box = as_box(box_coords[box_index])
+        # Re-allocating here is significantly faster than re-allocating inside
+        # of ``locate_box``; presumably because that function is kept simpler and
+        # numba can optimize better. Unfortunately, that means we have to keep
+        # trying until we succeed here; in most cases, success is immediate as
+        # the indices array will have enough capacity.
+        while True:
+            count, indices_size = locate_box(
+                box, tree, indices, indices_size, box_index + offset
+            )
+            if count != -1:
+                break
+            # Not enough capacity: grow capacity, discard partial work, retry.
+            indices_size = total_count
+            indices = grow(indices)
+        total_count += count
+    return indices, total_count
 
-    # Run a cumulative sum
-    total = 0
-    for i in range(1, n_box + 1):
-        total += counts[i]
-        counts[i] = total
 
-    # Now allocate appropriately
-    ii = np.empty(total, dtype=IntDType)
-    jj = np.empty(total, dtype=IntDType)
-    for i in nb.prange(n_box):  # pylint: disable=not-an-iterable
-        start = counts[i]
-        end = counts[i + 1]
-        ii[start:end] = i
-        indices = jj[start:end]
-        box = as_box(box_coords[i])
-        locate_box(box, tree, indices, True)
-
-    return ii, jj
+@nb.njit(cache=True, parallel=PARALLEL)
+def locate_boxes(box_coords: FloatArray, tree: CellTreeData, n_chunks: int):
+    chunks = np.array_split(box_coords, n_chunks)
+    offsets = np.zeros(n_chunks, dtype=IntDType)
+    for i, chunk in enumerate(chunks[:-1]):
+        offsets[i + 1] = offsets[i] + len(chunk)
+    # Setup (dummy) typed list for numba to store parallel results.
+    indices = [np.empty((0, 2), dtype=IntDType) for _ in range(n_chunks)]
+    counts = np.empty(n_chunks, dtype=IntDType)
+    for i in nb.prange(n_chunks):
+        indices[i], counts[i] = locate_boxes_helper(chunks[i], tree, offsets[i])
+    return concatenate_indices(indices, counts)
 
 
 # Inlining this function drives compilation time through the roof. It's
@@ -340,27 +394,18 @@ def collect_node_bounds(tree: CellTreeData) -> FloatArray:
     node_bounds[0, 2] = tree.bbox[2]
     node_bounds[0, 3] = tree.bbox[3]
 
-    stack = allocate_stack()
-    parent_stack = allocate_stack()
-    side_stack = allocate_stack()
-
-    # Right child
-    stack[0] = 2
-    parent_stack[0] = 0
-    side_stack[0] = 0
-    # Left child
-    stack[1] = 1
-    parent_stack[1] = 0
-    side_stack[1] = 1
-    # Stack size starts at two.
+    # Stack contains: node_index, parent_index, side (right/left)
+    ROOT = 0
+    RIGHT = 0
+    LEFT = 1
+    stack = allocate_triple_stack()
+    stack[0, :] = (2, ROOT, RIGHT)  # Right child
+    stack[1, :] = (1, ROOT, LEFT)  # Left child
     size = 2
 
     while size > 0:
         # Collect from stacks
-        # Sizes are synchronized.
-        parent_index, _ = pop(parent_stack, size)
-        side, _ = pop(side_stack, size)
-        node_index, size = pop(stack, size)
+        node_index, parent_index, side, size = pop_triple(stack, size)
 
         parent = tree.nodes[parent_index]
         bbox = node_bounds[parent_index]
@@ -388,14 +433,9 @@ def collect_node_bounds(tree: CellTreeData) -> FloatArray:
         right_child = left_child + 1
 
         # Right child
-        push(parent_stack, node_index, size)
-        push(side_stack, 0, size)
-        stack, size = push(stack, right_child, size)
-
+        stack, size = push_triple(stack, right_child, node_index, RIGHT, size)
         # Left child
-        push(parent_stack, node_index, size)
-        push(side_stack, 1, size)
-        stack, size = push(stack, left_child, size)
+        stack, size = push_triple(stack, left_child, node_index, LEFT, size)
 
     return node_bounds
 

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -391,7 +391,7 @@ def locate_edges(box_coords: FloatArray, tree: CellTreeData, n_chunks: int):
         )
 
     total_size = sum(counts)
-    xy = np.empty((total_size, 2, 2), dtype=IntDType)
+    xy = np.empty((total_size, 2, 2), dtype=FloatDType)
     start = 0
     for i, size in enumerate(counts):
         end = start + size

--- a/numba_celltree/utils.py
+++ b/numba_celltree/utils.py
@@ -7,7 +7,7 @@ from numba.core import cgutils
 from numba.extending import intrinsic
 
 from numba_celltree.constants import (
-    INITIAL_TREE_DEPTH,
+    INITIAL_STACK_LENGTH,
     MAX_N_VERTEX,
     NDIM,
     STACK_ALLOCATE_STATIC_ARRAYS,
@@ -17,16 +17,29 @@ from numba_celltree.constants import (
 
 
 @nb.njit(inline="always")
+def allocate_stack():
+    return np.empty(INITIAL_STACK_LENGTH, dtype=IntDType)
+
+
+@nb.njit(inline="always")
+def allocate_double_stack():
+    return np.empty((INITIAL_STACK_LENGTH, 2), dtype=IntDType)
+
+
+@nb.njit(inline="always")
+def allocate_triple_stack():
+    return np.empty((INITIAL_STACK_LENGTH, 3), dtype=IntDType)
+
+
+@nb.njit(inline="always")
 def pop(array, size):
     return array[size - 1], size - 1
 
 
 @nb.njit(inline="always")
 def push(array, value, size):
-    if size >= array.size:
-        new = np.empty(array.size * 2, dtype=array.dtype)
-        new[: array.size] = array[:]
-        array = new
+    if size >= len(array):
+        array = grow(array)
     array[size] = value
     return array, size + 1
 
@@ -35,6 +48,53 @@ def push(array, value, size):
 def copy(src, dst, n) -> None:
     for i in range(n):
         dst[i] = src[i]
+    return
+
+
+@nb.njit(inline="always")
+def push_both(stack, a, b, size):
+    if size >= len(stack):
+        stack = grow(stack)
+    stack[size, 0] = a
+    stack[size, 1] = b
+    return stack, size + 1
+
+
+@nb.njit(inline="always")
+def pop_both(stack, size):
+    index = size - 1
+    a = stack[index, 0]
+    b = stack[index, 1]
+    return a, b, index
+
+
+@nb.njit(inline="always")
+def push_triple(stack, a, b, c, size):
+    if size >= len(stack):
+        stack = grow(stack)
+    stack[size, 0] = a
+    stack[size, 1] = b
+    stack[size, 2] = c
+    return stack, size + 1
+
+
+@nb.njit(inline="always")
+def pop_triple(stack, size):
+    index = size - 1
+    a = stack[index, 0]
+    b = stack[index, 1]
+    c = stack[index, 2]
+    return a, b, c, index
+
+
+@nb.njit(inline="always")
+def grow(array: np.ndarray) -> np.ndarray:
+    """Double storage capacity."""
+    n = len(array)
+    new_shape = (2 * n,) + array.shape[1:]
+    new = np.empty(new_shape, dtype=array.dtype)
+    new[:n] = array[:]
+    return new
 
 
 # Ensure these are constants for numba
@@ -94,8 +154,3 @@ else:
     @nb.njit(inline="always")
     def allocate_box_polygon():
         return np.empty((4, 2), dtype=FloatDType)
-
-
-@nb.njit(inline="always")
-def allocate_stack():
-    return np.empty(INITIAL_TREE_DEPTH, dtype=IntDType)

--- a/pixi.lock
+++ b/pixi.lock
@@ -12153,7 +12153,7 @@ packages:
   timestamp: 1718888686982
 - kind: pypi
   name: numba-celltree
-  version: 0.2.0
+  version: 0.2.1
   path: .
   sha256: 2bd3845e2ef418031ed6547ed4a50525b73be2ccae26e299dad0f6f6f824e02f
   requires_dist:

--- a/pixi.lock
+++ b/pixi.lock
@@ -12155,7 +12155,7 @@ packages:
   name: numba-celltree
   version: 0.2.1
   path: .
-  sha256: 2bd3845e2ef418031ed6547ed4a50525b73be2ccae26e299dad0f6f6f824e02f
+  sha256: 71e0b33c7b3a2ab6350e6dc49d6a69ec26fbc81275fe0251e28f32dd48cdcb64
   requires_dist:
   - numba
   - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ twine = "*"
 [tool.pixi.tasks]
 pre-commit = "pre-commit run --all-files"
 test = "NUMBA_DISABLE_JIT=1 pytest --cov=numba_celltree --cov-report xml --cov-report term"
+test-single-thread = "NUMBA_DISABLE_JIT=1 NUMBA_NUM_THREADS=1 pytest"
+test-jit = "NUMBA_DISABLE_JIT=0 pytest"
 docs = "NUMBA_DISABLE_JIT=1 sphinx-build docs docs/_build"
 all = { depends_on = ["pre-commit", "test", "docs"]}
 pypi-publish = "rm --recursive --force dist && python -m build && twine check dist/* && twine upload dist/*"

--- a/tests/test_algorithms/test_line_box_clip.py
+++ b/tests/test_algorithms/test_line_box_clip.py
@@ -130,6 +130,8 @@ def test_line_box_clip_degeneracy(line_clip, box):
         b = Point(*b)
         # c, d are the clipped points
         actual, actual_c, actual_d = line_clip(a, b, box)
+        print(actual_c, c)
+        print(actual_d, d)
         assert intersects is actual
         assert np.allclose(actual_c, c, equal_nan=True)
         assert np.allclose(actual_d, d, equal_nan=True)
@@ -280,4 +282,13 @@ def test_line_box_clip_degeneracy(line_clip, box):
         True,
         (2.0, 0.0),
         (2.0, 2.0),
+    )
+
+    # Diagonal line of length (1, 1), touching upper left corner.
+    assert_expected(
+        (-1.0, 1.0),
+        (0.0, 2.0),
+        False,
+        (np.nan, np.nan),
+        (np.nan, np.nan),
     )

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -1,7 +1,3 @@
-import os
-
-os.environ["NUMBA_DISABLE_JIT"] = "1"
-os.environ["NUMBA_NUM_THREADS"] = "1"
 import pathlib
 import shutil
 

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -1,3 +1,7 @@
+import os
+
+os.environ["NUMBA_DISABLE_JIT"] = "1"
+
 import pathlib
 import shutil
 

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -1,3 +1,7 @@
+import os
+
+os.environ["NUMBA_DISABLE_JIT"] = "1"
+os.environ["NUMBA_NUM_THREADS"] = "1"
 import pathlib
 import shutil
 
@@ -371,18 +375,12 @@ def test_edge_lookup():
     expected_i = np.array([0, 1, 2])
     expected_j = np.array([0, 1, 2])
     expected_intersections = edge_coords[:3]
-    print(actual_i, expected_i)
-    print(actual_j, expected_j)
-    print(intersections, expected_intersections)
     assert np.array_equal(actual_i, expected_i)
     assert np.array_equal(actual_j, expected_j)
     assert np.allclose(intersections, expected_intersections)
 
     # Flip edge orientation
     actual_i, actual_j, intersections = tree.intersect_edges(edge_coords[:, ::-1])
-    print(actual_i, expected_i)
-    print(actual_j, expected_j)
-    print(intersections, expected_intersections[:, ::-1])
     assert np.array_equal(actual_i, expected_i)
     assert np.array_equal(actual_j, expected_j)
     assert np.allclose(intersections, expected_intersections[:, ::-1])

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -371,12 +371,18 @@ def test_edge_lookup():
     expected_i = np.array([0, 1, 2])
     expected_j = np.array([0, 1, 2])
     expected_intersections = edge_coords[:3]
+    print(actual_i, expected_i)
+    print(actual_j, expected_j)
+    print(intersections, expected_intersections)
     assert np.array_equal(actual_i, expected_i)
     assert np.array_equal(actual_j, expected_j)
     assert np.allclose(intersections, expected_intersections)
 
     # Flip edge orientation
     actual_i, actual_j, intersections = tree.intersect_edges(edge_coords[:, ::-1])
+    print(actual_i, expected_i)
+    print(actual_j, expected_j)
+    print(intersections, expected_intersections[:, ::-1])
     assert np.array_equal(actual_i, expected_i)
     assert np.array_equal(actual_j, expected_j)
     assert np.allclose(intersections, expected_intersections[:, ::-1])

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -1,7 +1,3 @@
-import os
-
-os.environ["NUMBA_DISABLE_JIT"] = "1"
-
 import pathlib
 import shutil
 

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -373,13 +373,13 @@ def test_edge_lookup():
     expected_intersections = edge_coords[:3]
     assert np.array_equal(actual_i, expected_i)
     assert np.array_equal(actual_j, expected_j)
-    assert np.array_equal(intersections, expected_intersections)
+    assert np.allclose(intersections, expected_intersections)
 
     # Flip edge orientation
     actual_i, actual_j, intersections = tree.intersect_edges(edge_coords[:, ::-1])
     assert np.array_equal(actual_i, expected_i)
     assert np.array_equal(actual_j, expected_j)
-    assert np.array_equal(intersections, expected_intersections[:, ::-1])
+    assert np.allclose(intersections, expected_intersections[:, ::-1])
 
 
 def test_example_material():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,7 +75,7 @@ def test_double_stack():
     stack, size = ut.push_both(stack, 1, 2, size)
     assert len(stack) == INITIAL_STACK_LENGTH * 2
     assert size == INITIAL_STACK_LENGTH + 1
-    assert np.array_equal(stack[32], (1, 2))
+    assert np.array_equal(stack[INITIAL_STACK_LENGTH], (1, 2))
 
     a, b, size = ut.pop_both(stack, size)
     assert size == INITIAL_STACK_LENGTH
@@ -98,7 +98,7 @@ def test_triple_stack():
     stack, size = ut.push_triple(stack, 1, 2, 3, size)
     assert len(stack) == INITIAL_STACK_LENGTH * 2
     assert size == INITIAL_STACK_LENGTH + 1
-    assert np.array_equal(stack[32], (1, 2, 3))
+    assert np.array_equal(stack[INITIAL_STACK_LENGTH], (1, 2, 3))
 
     a, b, c, size = ut.pop_triple(stack, size)
     assert size == INITIAL_STACK_LENGTH

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,19 @@ import numba as nb
 import numpy as np
 
 from numba_celltree import utils as ut
-from numba_celltree.constants import INITIAL_TREE_DEPTH, MAX_N_VERTEX
+from numba_celltree.constants import INITIAL_STACK_LENGTH, MAX_N_VERTEX
+
+
+def test_grow():
+    a = np.arange(10)
+    b = ut.grow(a)
+    assert b.shape == (20,)
+    assert np.array_equal(a, b[:10])
+
+    a = np.arange(20).reshape((10, 2))
+    b = ut.grow(a)
+    assert b.shape == (20, 2)
+    assert np.array_equal(a, b[:10])
 
 
 def test_pop():
@@ -49,12 +61,59 @@ def test_copy():
     assert np.array_equal(dst, [0, 1, 2, 0, 0])
 
 
+def test_double_stack():
+    stack = ut.allocate_double_stack()
+    assert stack.shape == (INITIAL_STACK_LENGTH, 2)
+
+    size = 1
+    stack, size = ut.push_both(stack, 1, 2, size)
+    assert size == 2
+    assert len(stack) == INITIAL_STACK_LENGTH
+    assert np.array_equal(stack[1], (1, 2))
+
+    size = INITIAL_STACK_LENGTH
+    stack, size = ut.push_both(stack, 1, 2, size)
+    assert len(stack) == INITIAL_STACK_LENGTH * 2
+    assert size == INITIAL_STACK_LENGTH + 1
+    assert np.array_equal(stack[32], (1, 2))
+
+    a, b, size = ut.pop_both(stack, size)
+    assert size == INITIAL_STACK_LENGTH
+    assert len(stack) == INITIAL_STACK_LENGTH * 2
+    assert a == 1
+    assert b == 2
+
+
+def test_triple_stack():
+    stack = ut.allocate_triple_stack()
+    assert stack.shape == (INITIAL_STACK_LENGTH, 3)
+
+    size = 1
+    stack, size = ut.push_triple(stack, 1, 2, 3, size)
+    assert size == 2
+    assert len(stack) == INITIAL_STACK_LENGTH
+    assert np.array_equal(stack[1], (1, 2, 3))
+
+    size = INITIAL_STACK_LENGTH
+    stack, size = ut.push_triple(stack, 1, 2, 3, size)
+    assert len(stack) == INITIAL_STACK_LENGTH * 2
+    assert size == INITIAL_STACK_LENGTH + 1
+    assert np.array_equal(stack[32], (1, 2, 3))
+
+    a, b, c, size = ut.pop_triple(stack, size)
+    assert size == INITIAL_STACK_LENGTH
+    assert len(stack) == INITIAL_STACK_LENGTH * 2
+    assert a == 1
+    assert b == 2
+    assert c == 3
+
+
 # These array is not returned properly to dynamic python. This is OK: these
 # arrays are exclusively for internal use to temporarily store values.
 @nb.njit
 def do_allocate_stack():
     stack = ut.allocate_stack()
-    return (stack.size == INITIAL_TREE_DEPTH) and (stack[:5].size == 5)
+    return (stack.size == INITIAL_STACK_LENGTH) and (stack[:5].size == 5)
 
 
 def test_allocate_stack():


### PR DESCRIPTION
This sets up parallelization by storing the (dynamically-resized) result in a list of numpy arrays (which numba can handle).

This seems to give a 30% performance improvement over the older scheme of querying to count, allocating, querying again.
Numba remains quite sensitive though: allocating inside the inner function results in a slow down instead!

This also cleans up some of the stack logic, using 2D arrays instead of multiple 1D arrays; this is safer since they must be synchronized in size anyway.