### PR TITLE
Add tolerance as argument

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,8 +10,8 @@ CellTree2d
 Changelog
 =========
 
-[Unreleased]
-------------
+[0.4.0 2025-04-10]
+------------------
 
 Added
 ~~~~~
@@ -24,11 +24,15 @@ Added
 Changed
 ~~~~~~~
 
-- There have been some changes to check edge cases in the algorithms. Instead of
-  comparing areas to a fixed tolerance value (1e-9), we now compare distances to
-  a small tolerance value, which is either estimated or set by the user. This
-  should improve the accuracy of the algorithms and reduce the number of false
-  negatives in edge cases.
+- Edge case handling has been improved. Dynamic tolerances are now
+  automatically estimated or can be optionally provided for queries to handle
+  floating point errors. In previous versions, the size of a cross product was
+  compared with a static tolerance value of 1e-9, which made the tolerance
+  effectively an area measure, or relative depending on the length of the edge
+  rather than the perpendicular distance to the vertex. The current approach
+  computes an actual distance, making the tolerance straightforward to
+  interpret. The new defaults should result in fewer false positives and false
+  negatives.
 
 [0.3.0 2025-03-25]
 ------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,11 +17,10 @@ Added
 ~~~~~
 
 - ``tolerance`` argument to make tolerance configurable in
-  :meth:`CellTree2d.locate_points`, :meth:`CellTree2d.intersect_edges`,
-  :meth:`EdgeCellTree2d.intersect_edges`, :meth:`EdgeCellTree2d.locate_points`,
-  and :class:`EdgeCellTree2d` constructor. This allows for more lenient queries
-  when working with datasets with large spatial coordinates. The default value
-  is set to ``1e-9``, which is consistent with previous releases.
+  :meth:`CellTree2d.locate_points`, :meth:`EdgeCellTree2d.locate_points`, and
+  :class:`EdgeCellTree2d` constructor. This allows for more lenient queries when
+  working with datasets with large spatial coordinates. The default value is set
+  to ``1e-9``, which is consistent with previous releases.
 
 [0.3.0 2025-03-25]
 ------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,19 @@ CellTree2d
 Changelog
 =========
 
+[Unreleased]
+------------
+
+Added
+~~~~~
+
+- ``tolerance`` argument to make tolerance configurable in
+  :meth:`CellTree2d.locate_points`, :meth:`CellTree2d.intersect_edges`,
+  :meth:`EdgeCellTree2d.intersect_edges`, :meth:`EdgeCellTree2d.locate_points`,
+  and :class:`EdgeCellTree2d` constructor. This allows for more lenient queries
+  when working with datasets with large spatial coordinates. The default value
+  is set to ``1e-9``, which is consistent with previous releases.
+
 [0.3.0 2025-03-25]
 ------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,8 +19,7 @@ Added
 - ``tolerance`` argument to make tolerance configurable in
   :meth:`CellTree2d.locate_points`, :meth:`EdgeCellTree2d.locate_points`, and
   :class:`EdgeCellTree2d` constructor. This allows for more lenient queries when
-  working with datasets with large spatial coordinates. The default value is set
-  to ``1e-9``, which is consistent with previous releases.
+  working with datasets with large spatial coordinates. 
 
 [0.3.0 2025-03-25]
 ------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,6 +21,15 @@ Added
   :class:`EdgeCellTree2d` constructor. This allows for more lenient queries when
   working with datasets with large spatial coordinates. 
 
+Changed
+~~~~~~~
+
+- There have been some changes to check edge cases in the algorithms. Instead of
+  comparing areas to a fixed tolerance value (1e-9), we now compare distances to
+  a small tolerance value, which is either estimated or set by the user. This
+  should improve the accuracy of the algorithms and reduce the number of false
+  negatives in edge cases.
+
 [0.3.0 2025-03-25]
 ------------------
 

--- a/examples/spatial_indexing_1d_network.py
+++ b/examples/spatial_indexing_1d_network.py
@@ -1,13 +1,13 @@
 """
-Spatial indexing of 1D networks and linear geometry"
-====================================================
+Spatial indexing of 1D networks and linear geometry
+===================================================
 
-This example demonstrates how to use the `numba_celltree` package to index 1D
-grids. The package provides a :class:`EdgeCellTree` class that constructs a cell
-tree for 1D networks and linear geometries. The package currently supports the
-following operations:
+This example demonstrates how to use the ``numba_celltree`` package to index 1D
+grids. The package provides a :class:`EdgeCellTree` class that constructs a
+cell tree for 1D networks and linear geometries. The package currently supports
+the following operations:
 
-* Location points
+* Locating points
 * Locating line segments
 
 This example provides an introduction to searching a cell tree for each of
@@ -54,9 +54,10 @@ i = tree.locate_points(points)
 i
 
 # %%
-# This returns the indices of the edges in the network on which the points
-# are located. Note that the last point is outside the grid, so it returns -1.
-# We'll have to filter those out first. Let's plot them:
+# This returns the indices of the edges that contain each point, with -1
+# indicating points outside the network. We'll have to filter those out first.
+# Let's plot them:
+
 
 ii = i[i != -1]
 
@@ -85,20 +86,20 @@ ax.add_collection(LineCollection(segments, color="gray", linewidth=3))
 
 # %%
 # Let's now intersect these line segments with the edges in the network.
-segment_index, tree_edge_index, xy_interesection = tree.intersect_edges(segments)
-xy_interesection
+segment_index, tree_edge_index, xy_intersection = tree.intersect_edges(segments)
+xy_intersection
 
 # %%
-# The `intersect_edges` method returns the indices of the segments in the input
-# that intersect with the edges in the network. It also returns the indices of
-# the edges in the network that intersect with the segments, and the coordinates
-# of the intersection points. Let's plot the results:
+# The ``intersect_edges`` method returns three arrays: which input segments
+# intersect with the network, which network edges they intersect with, and the
+# coordinates of each intersection point.
 #
+# Let's plot the results:
 
 fig, ax = plt.subplots()
 demo.plot_edges(node_x, node_y, edges, ax, color="black")
 demo.plot_edges(node_x, node_y, edges[tree_edge_index], ax, color="blue", linewidth=3)
 ax.add_collection(LineCollection(segments, color="gray", linewidth=3))
-ax.scatter(*xy_interesection.transpose(), s=60, color="darkgreen", zorder=2.5)
+ax.scatter(*xy_intersection.transpose(), s=60, color="darkgreen", zorder=2.5)
 
 # %%

--- a/numba_celltree/__init__.py
+++ b/numba_celltree/__init__.py
@@ -1,6 +1,6 @@
 from numba_celltree.celltree import CellTree2d
 from numba_celltree.edge_celltree import EdgeCellTree2d
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = ("CellTree2d", "EdgeCellTree2d")

--- a/numba_celltree/algorithms/barycentric_triangle.py
+++ b/numba_celltree/algorithms/barycentric_triangle.py
@@ -49,6 +49,7 @@ def barycentric_triangle_weights(
     face_indices: IntArray,
     faces: IntArray,
     vertices: FloatArray,
+    tolerance: float,
 ) -> FloatArray:
     n_points = len(points)
     weights = np.zeros((n_points, 3), dtype=FloatDType)

--- a/numba_celltree/algorithms/barycentric_wachspress.py
+++ b/numba_celltree/algorithms/barycentric_wachspress.py
@@ -34,7 +34,7 @@ def interp_edge_case(a, U, p, weights, i, j):
     return
 
 
-@nb.njit
+@nb.njit()
 def compute_weights(
     polygon: FloatArray, p: Point, weights: FloatArray, tolerance: float
 ) -> None:
@@ -46,8 +46,7 @@ def compute_weights(
     b = as_point(polygon[0])
     U = to_vector(a, b)
     V = to_vector(a, p)
-    W = to_vector(b, p)
-    L2i = W.x * W.x + W.y * W.y
+    L2i = U.x * U.x + U.y * U.y
     Ai = abs(cross_product(U, V))
     if (Ai * Ai) < ((tolerance * L2i) * tolerance):
         # Note: weights may be differently sized than polygon! Hence n-1
@@ -59,17 +58,16 @@ def compute_weights(
         i_next = (i + 1) % n
         c = as_point(polygon[i_next])
 
-        V = to_vector(a, c)
-        Ci = abs(cross_product(U, V))
+        W = to_vector(a, c)
+        Ci = abs(cross_product(U, W))
 
-        U = to_vector(b, p)
-        V = to_vector(b, c)
-        W = to_vector(c, p)
-        L2j = W.x * W.x + W.y * W.y
+        U = to_vector(b, c)
+        V = to_vector(b, p)
+        L2j = U.x * U.x + U.y * U.y
         Aj = abs(cross_product(U, V))
 
         if (Aj * Aj) < ((tolerance * L2j) * tolerance):
-            interp_edge_case(b, V, p, weights, i, i_next)
+            interp_edge_case(b, U, p, weights, i, i_next)
             return
 
         w = 2 * Ci / (Ai * Aj)
@@ -79,7 +77,7 @@ def compute_weights(
         # Setup next iteration
         a = b
         b = c
-        U = to_vector(a, b)
+        # U = U
         Ai = Aj
 
     # normalize weights

--- a/numba_celltree/algorithms/barycentric_wachspress.py
+++ b/numba_celltree/algorithms/barycentric_wachspress.py
@@ -46,8 +46,10 @@ def compute_weights(
     b = as_point(polygon[0])
     U = to_vector(a, b)
     V = to_vector(a, p)
+    W = to_vector(b, p)
+    L2i = W.x * W.x + W.y * W.y
     Ai = abs(cross_product(U, V))
-    if Ai < tolerance:
+    if (Ai * Ai) < ((tolerance * L2i) * tolerance):
         # Note: weights may be differently sized than polygon! Hence n-1
         # instead of -1.
         interp_edge_case(a, U, p, weights, n - 1, 0)
@@ -62,9 +64,11 @@ def compute_weights(
 
         U = to_vector(b, p)
         V = to_vector(b, c)
+        W = to_vector(c, p)
+        L2j = W.x * W.x + W.y * W.y
         Aj = abs(cross_product(U, V))
 
-        if Aj < tolerance:
+        if (Aj * Aj) < ((tolerance * L2j) * tolerance):
             interp_edge_case(b, V, p, weights, i, i_next)
             return
 

--- a/numba_celltree/algorithms/cyrus_beck.py
+++ b/numba_celltree/algorithms/cyrus_beck.py
@@ -19,7 +19,7 @@ from typing import Sequence, Tuple
 import numba as nb
 import numpy as np
 
-from numba_celltree.constants import Point, Vector
+from numba_celltree.constants import Point, Vector, TOLERANCE_ON_EDGE
 from numba_celltree.geometry_utils import (
     as_point,
     cross_product,
@@ -142,7 +142,7 @@ def collinear_case(a: Point, b: Point, v0: Point, v1: Point) -> Tuple[Point, Poi
 # Too big to inline. Drives compilation time through the roof for no benefit.
 @nb.njit(inline="never")
 def cyrus_beck_line_polygon_clip(
-    a: Point, b: Point, poly: Sequence[Point], tolerance: float
+    a: Point, b: Point, poly: Sequence[Point]
 ) -> Tuple[bool, Point, Point]:
     """
     In short, the basic idea:
@@ -164,6 +164,7 @@ def cyrus_beck_line_polygon_clip(
     A valid intersection falls on the domain of the parametrized segment:
     0 <= t <= 1.0
     """
+    tolerance = TOLERANCE_ON_EDGE
     length = len(poly)
     s = to_vector(a, b)
 

--- a/numba_celltree/algorithms/cyrus_beck.py
+++ b/numba_celltree/algorithms/cyrus_beck.py
@@ -142,7 +142,7 @@ def collinear_case(a: Point, b: Point, v0: Point, v1: Point) -> Tuple[Point, Poi
 # Too big to inline. Drives compilation time through the roof for no benefit.
 @nb.njit(inline="never")
 def cyrus_beck_line_polygon_clip(
-    a: Point, b: Point, poly: Sequence[Point]
+    a: Point, b: Point, poly: Sequence[Point], tolerance: float
 ) -> Tuple[bool, Point, Point]:
     """
     In short, the basic idea:
@@ -171,8 +171,8 @@ def cyrus_beck_line_polygon_clip(
     if s.x == 0 and s.y == 0:
         return NO_INTERSECTION
     # Test whether line is fully enclosed in polygon
-    a_inside = point_in_polygon_or_on_edge(a, poly)
-    b_inside = point_in_polygon_or_on_edge(b, poly)
+    a_inside = point_in_polygon_or_on_edge(a, poly, tolerance)
+    b_inside = point_in_polygon_or_on_edge(b, poly, tolerance)
     if a_inside and b_inside:
         return True, a, b
 

--- a/numba_celltree/algorithms/cyrus_beck.py
+++ b/numba_celltree/algorithms/cyrus_beck.py
@@ -19,7 +19,7 @@ from typing import Sequence, Tuple
 import numba as nb
 import numpy as np
 
-from numba_celltree.constants import Point, Vector, TOLERANCE_ON_EDGE
+from numba_celltree.constants import TOLERANCE_ON_EDGE, Point, Vector
 from numba_celltree.geometry_utils import (
     as_point,
     cross_product,

--- a/numba_celltree/algorithms/cyrus_beck.py
+++ b/numba_celltree/algorithms/cyrus_beck.py
@@ -19,7 +19,7 @@ from typing import Sequence, Tuple
 import numba as nb
 import numpy as np
 
-from numba_celltree.constants import TOLERANCE_ON_EDGE, Point, Vector
+from numba_celltree.constants import Point, Vector
 from numba_celltree.geometry_utils import (
     as_point,
     cross_product,
@@ -142,7 +142,7 @@ def collinear_case(a: Point, b: Point, v0: Point, v1: Point) -> Tuple[Point, Poi
 # Too big to inline. Drives compilation time through the roof for no benefit.
 @nb.njit(inline="never")
 def cyrus_beck_line_polygon_clip(
-    a: Point, b: Point, poly: Sequence[Point]
+    a: Point, b: Point, poly: Sequence[Point], tolerance: float
 ) -> Tuple[bool, Point, Point]:
     """
     In short, the basic idea:
@@ -164,7 +164,6 @@ def cyrus_beck_line_polygon_clip(
     A valid intersection falls on the domain of the parametrized segment:
     0 <= t <= 1.0
     """
-    tolerance = TOLERANCE_ON_EDGE
     length = len(poly)
     s = to_vector(a, b)
 

--- a/numba_celltree/celltree.py
+++ b/numba_celltree/celltree.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numba as nb
 
@@ -88,7 +88,7 @@ class CellTree2d(CellTree2dBase):
         )
 
     def locate_points(
-        self, points: FloatArray, tolerance: float = TOLERANCE_ON_EDGE
+        self, points: FloatArray, tolerance: Optional[float] = None
     ) -> IntArray:
         """
         Find the index of a face that contains a point.
@@ -111,6 +111,8 @@ class CellTree2d(CellTree2dBase):
             For every point, the index of the face it falls in. Points not
             falling in any faces are marked with a value of ``-1``.
         """
+        if tolerance is None:
+            tolerance = TOLERANCE_ON_EDGE
         points = cast_vertices(points)
         return locate_points(points, self.celltree_data, tolerance)
 
@@ -286,7 +288,7 @@ class CellTree2d(CellTree2dBase):
     def compute_barycentric_weights(
         self,
         points: FloatArray,
-        tolerance: float = TOLERANCE_ON_EDGE,
+        tolerance: Optional[float] = None,
     ) -> Tuple[IntArray, FloatArray]:
         """
         Compute barycentric weights for points located inside of the grid.
@@ -310,6 +312,8 @@ class CellTree2d(CellTree2dBase):
             face in which the point is located. For points not falling in any
             faces, the weight of all vertices is 0.
         """
+        if tolerance is None:
+            tolerance = TOLERANCE_ON_EDGE
         face_indices = self.locate_points(points, tolerance)
         n_max_vert = self.faces.shape[1]
         if n_max_vert > 3:

--- a/numba_celltree/celltree.py
+++ b/numba_celltree/celltree.py
@@ -105,10 +105,12 @@ class CellTree2d(CellTree2dBase):
         ----------
         points: ndarray of floats with shape ``(n_point, 2)``
             Coordinates of the points to be located.
-        tolerance: float, optional, default: 1e-9
-            The tolerance used to determine whether a point is on an edge.
-            If the distance from the point to the edge is smaller than this
-            value, the point is considered to be on the edge.
+        tolerance: float, optional
+            The tolerance used to determine whether a point is on an edge. If
+            the distance from the point to the edge is smaller than this value,
+            the point is considered to be on the edge. If None, the method tries
+            to estimate an appropriate tolerance by multiplying the maximum
+            diagonal of the bounding boxes with 1e-12.
 
         Returns
         -------
@@ -302,10 +304,12 @@ class CellTree2d(CellTree2dBase):
         ----------
         points: ndarray of floats with shape ``(n_point, 2)``
             Coordinates of the points to be located.
-        tolerance: float, optional, default: 1e-9
-            The tolerance used to determine whether a point is on an edge.
-            If the distance from the point to the edge is smaller than this
-            value, the point is considered to be on the edge.
+        tolerance: float, optional
+            The tolerance used to determine whether a point is on an edge. If
+            the distance from the point to the edge is smaller than this value,
+            the point is considered to be on the edge. If None, the method tries
+            to estimate an appropriate tolerance by multiplying the maximum
+            diagonal of the bounding boxes with 1e-12.
 
         Returns
         -------

--- a/numba_celltree/celltree.py
+++ b/numba_celltree/celltree.py
@@ -10,9 +10,13 @@ from numba_celltree.algorithms import (
     polygons_intersect,
 )
 from numba_celltree.cast import cast_bboxes, cast_edges, cast_faces, cast_vertices
-from numba_celltree.celltree_base import CellTree2dBase, bbox_tree
+from numba_celltree.celltree_base import (
+    CellTree2dBase,
+    bbox_distances,
+    bbox_tree,
+    default_tolerance,
+)
 from numba_celltree.constants import (
-    TOLERANCE_ON_EDGE,
     CellTreeData,
     FloatArray,
     IntArray,
@@ -77,6 +81,7 @@ class CellTree2d(CellTree2dBase):
         self.bb_indices = bb_indices
         self.bb_coords = bb_coords
         self.bbox = bbox_tree(bb_coords)
+        self.bb_distances = bbox_distances(bb_coords)
         self.celltree_data = CellTreeData(
             self.faces,
             self.vertices,
@@ -112,7 +117,7 @@ class CellTree2d(CellTree2dBase):
             falling in any faces are marked with a value of ``-1``.
         """
         if tolerance is None:
-            tolerance = TOLERANCE_ON_EDGE
+            tolerance = default_tolerance(self.bb_distances[:, 2])
         points = cast_vertices(points)
         return locate_points(points, self.celltree_data, tolerance)
 
@@ -313,7 +318,7 @@ class CellTree2d(CellTree2dBase):
             faces, the weight of all vertices is 0.
         """
         if tolerance is None:
-            tolerance = TOLERANCE_ON_EDGE
+            tolerance = default_tolerance(self.bb_distances[:, 2])
         face_indices = self.locate_points(points, tolerance)
         n_max_vert = self.faces.shape[1]
         if n_max_vert > 3:

--- a/numba_celltree/celltree.py
+++ b/numba_celltree/celltree.py
@@ -258,7 +258,6 @@ class CellTree2d(CellTree2dBase):
     def intersect_edges(
         self,
         edge_coords: FloatArray,
-        tolerance: float = TOLERANCE_ON_EDGE,
     ) -> Tuple[IntArray, IntArray, FloatArray]:
         """
         Find the index of a face intersecting with an edge.
@@ -267,10 +266,6 @@ class CellTree2d(CellTree2dBase):
         ----------
         edge_coords: ndarray of floats with shape ``(n_edge, 2, 2)``
             Every row containing ``((x0, y0), (x1, y1))``.
-        tolerance: float, optional, default: 1e-9
-            The tolerance used to determine whether a point is on an edge.
-            If the distance from the point to the edge is smaller than this
-            value, the point is considered to be on the edge.
 
         Returns
         -------
@@ -286,7 +281,7 @@ class CellTree2d(CellTree2dBase):
         """
         edge_coords = cast_edges(edge_coords)
         n_chunks = nb.get_num_threads()
-        return locate_edge_faces(edge_coords, self.celltree_data, n_chunks, tolerance)
+        return locate_edge_faces(edge_coords, self.celltree_data, n_chunks)
 
     def compute_barycentric_weights(
         self,

--- a/numba_celltree/celltree_base.py
+++ b/numba_celltree/celltree_base.py
@@ -4,6 +4,8 @@ from typing import Optional
 import numpy as np
 
 from numba_celltree.constants import (
+    MIN_TOLERANCE,
+    TOLERANCE_FACTOR,
     BoolArray,
     FloatArray,
     FloatDType,
@@ -21,6 +23,33 @@ def bbox_tree(bb_coords: FloatArray) -> FloatArray:
     ymin = bb_coords[:, 2].min()
     ymax = bb_coords[:, 3].max()
     return np.array([xmin, xmax, ymin, ymax], dtype=FloatDType)
+
+
+def bbox_distances(bb_coords: FloatArray) -> FloatArray:
+    """Compute the dx, dy and dxy distances for the bounding boxes.
+
+    Parameters
+    ----------
+    bb_coords: np.ndarray of shape (n_nodes, 4)
+        The bounding box coordinates of the nodes.
+
+    Returns
+    -------
+    distances: np.ndarray of shape (n_nodes, 3)
+        Respectively the dx, dy and dxy distances for the bounding boxes.
+    """
+    distances = np.empty((bb_coords.shape[0], 3), dtype=FloatDType)
+    # dx
+    distances[:, 0] = bb_coords[:, 1] - bb_coords[:, 0]
+    # dy
+    distances[:, 1] = bb_coords[:, 3] - bb_coords[:, 2]
+    # dxy
+    distances[:, 2] = np.sqrt(distances[:, 0] ** 2 + distances[:, 1] ** 2)
+    return distances
+
+
+def default_tolerance(bb_diagonal: FloatArray) -> float:
+    return max(MIN_TOLERANCE, TOLERANCE_FACTOR * max(bb_diagonal))
 
 
 class CellTree2dBase(abc.ABC):

--- a/numba_celltree/celltree_base.py
+++ b/numba_celltree/celltree_base.py
@@ -1,9 +1,9 @@
 import abc
+from typing import Optional
 
 import numpy as np
 
 from numba_celltree.constants import (
-    TOLERANCE_ON_EDGE,
     BoolArray,
     FloatArray,
     FloatDType,
@@ -26,7 +26,7 @@ def bbox_tree(bb_coords: FloatArray) -> FloatArray:
 class CellTree2dBase(abc.ABC):
     @abc.abstractmethod
     def locate_points(
-        self, points: FloatArray, tolerance: float = TOLERANCE_ON_EDGE
+        self, points: FloatArray, tolerance: Optional[float] = None
     ) -> IntArray:
         pass
 

--- a/numba_celltree/celltree_base.py
+++ b/numba_celltree/celltree_base.py
@@ -3,6 +3,7 @@ import abc
 import numpy as np
 
 from numba_celltree.constants import (
+    TOLERANCE_ON_EDGE,
     BoolArray,
     FloatArray,
     FloatDType,
@@ -24,7 +25,9 @@ def bbox_tree(bb_coords: FloatArray) -> FloatArray:
 
 class CellTree2dBase(abc.ABC):
     @abc.abstractmethod
-    def locate_points(self, points: FloatArray) -> IntArray:
+    def locate_points(
+        self, points: FloatArray, tolerance: float = TOLERANCE_ON_EDGE
+    ) -> IntArray:
         pass
 
     @property

--- a/numba_celltree/constants.py
+++ b/numba_celltree/constants.py
@@ -143,7 +143,7 @@ FILL_VALUE = -1
 # results in required stack of 32.
 INITIAL_STACK_LENGTH = 32
 # Floating point slack
-TOLERANCE_ON_EDGE = 1e-2
+TOLERANCE_ON_EDGE = 1e-9
 
 FLOAT_MIN = np.finfo(FloatDType).min
 FLOAT_MAX = np.finfo(FloatDType).max

--- a/numba_celltree/constants.py
+++ b/numba_celltree/constants.py
@@ -143,7 +143,7 @@ FILL_VALUE = -1
 # results in required stack of 32.
 INITIAL_STACK_LENGTH = 32
 # Floating point slack
-TOLERANCE_ON_EDGE = 1e-9
+TOLERANCE_ON_EDGE = 1e-2
 
 FLOAT_MIN = np.finfo(FloatDType).min
 FLOAT_MAX = np.finfo(FloatDType).max

--- a/numba_celltree/constants.py
+++ b/numba_celltree/constants.py
@@ -144,6 +144,8 @@ FILL_VALUE = -1
 INITIAL_STACK_LENGTH = 32
 # Floating point slack
 TOLERANCE_ON_EDGE = 1e-9
+MIN_TOLERANCE = 1e-15
+TOLERANCE_FACTOR = 1e-12
 
 FLOAT_MIN = np.finfo(FloatDType).min
 FLOAT_MAX = np.finfo(FloatDType).max

--- a/numba_celltree/constants.py
+++ b/numba_celltree/constants.py
@@ -143,7 +143,6 @@ FILL_VALUE = -1
 # results in required stack of 32.
 INITIAL_STACK_LENGTH = 32
 # Floating point slack
-TOLERANCE_ON_EDGE = 1e-9
 MIN_TOLERANCE = 1e-15
 TOLERANCE_FACTOR = 1e-12
 

--- a/numba_celltree/edge_celltree.py
+++ b/numba_celltree/edge_celltree.py
@@ -99,7 +99,8 @@ class EdgeCellTree2d(CellTree2dBase):
         return locate_points_on_edge(points, self.celltree_data, tolerance)
 
     def intersect_edges(
-        self, edge_coords: FloatArray,
+        self,
+        edge_coords: FloatArray,
     ) -> Tuple[IntArray, IntArray, FloatArray]:
         """
         Find the index of an edge intersecting with an edge.

--- a/numba_celltree/edge_celltree.py
+++ b/numba_celltree/edge_celltree.py
@@ -11,7 +11,6 @@ from numba_celltree.celltree_base import (
     default_tolerance,
 )
 from numba_celltree.constants import (
-    MIN_TOLERANCE,
     CellTreeData,
     FloatArray,
     IntArray,
@@ -50,9 +49,6 @@ class EdgeCellTree2d(CellTree2dBase):
     ):
         # Determine the tolerance for the bounding boxes. This is mainly
         # relevant when edges are axis-aligned.
-        bb_coords_preliminary = build_edge_bboxes(edges, vertices, MIN_TOLERANCE)
-        distances_preliminary = bbox_distances(bb_coords_preliminary)
-        tolerance = default_tolerance(distances_preliminary[:, 2])
         if n_buckets < 2:
             raise ValueError("n_buckets must be >= 2")
         if cells_per_leaf < 1:
@@ -60,7 +56,7 @@ class EdgeCellTree2d(CellTree2dBase):
 
         vertices = cast_vertices(vertices, copy=True)
 
-        bb_coords = build_edge_bboxes(edges, vertices, tolerance)
+        bb_coords = build_edge_bboxes(edges, vertices)
         nodes, bb_indices = initialize(edges, bb_coords, n_buckets, cells_per_leaf)
         self.vertices = vertices
         self.edges = edges

--- a/numba_celltree/edge_celltree.py
+++ b/numba_celltree/edge_celltree.py
@@ -39,13 +39,6 @@ class EdgeCellTree2d(CellTree2dBase):
         to only 1, but this doubles memory footprint for slightly faster
         lookup. Increase this to reduce memory usage at the cost of lookup
         performance.
-    tolerance: float, optional
-        Tolerance used to build edge bounding boxes, which are used to traverse
-        the celltree. Specifying a tolerance is mainly relevant when edges are
-        axis-aligned. If None, the method tries to estimate an appropriate
-        tolerance by multiplying the maximum diagonal of the bounding boxes with
-        1e-12.
-
     """
 
     def __init__(
@@ -54,12 +47,12 @@ class EdgeCellTree2d(CellTree2dBase):
         edges: IntArray,
         n_buckets: int = 4,
         cells_per_leaf: int = 2,
-        tolerance: Optional[float] = None,
     ):
-        if tolerance is None:
-            bb_coords_preliminary = build_edge_bboxes(edges, vertices, MIN_TOLERANCE)
-            distances = bbox_distances(bb_coords_preliminary)
-            tolerance = default_tolerance(distances[:, 2])
+        # Determine the tolerance for the bounding boxes. This is mainly
+        # relevant when edges are axis-aligned.
+        bb_coords_preliminary = build_edge_bboxes(edges, vertices, MIN_TOLERANCE)
+        distances_preliminary = bbox_distances(bb_coords_preliminary)
+        tolerance = default_tolerance(distances_preliminary[:, 2])
         if n_buckets < 2:
             raise ValueError("n_buckets must be >= 2")
         if cells_per_leaf < 1:

--- a/numba_celltree/edge_celltree.py
+++ b/numba_celltree/edge_celltree.py
@@ -37,7 +37,7 @@ class EdgeCellTree2d(CellTree2dBase):
     tolerance: float, optional, default: 1e-9
         Tolerance used to build edge bounding boxes, which are used to traverse
         the celltree. Specifying a tolerance is mainly relevant when edges are
-        axis-aligned. 
+        axis-aligned.
     """
 
     def __init__(

--- a/numba_celltree/edge_celltree.py
+++ b/numba_celltree/edge_celltree.py
@@ -35,8 +35,9 @@ class EdgeCellTree2d(CellTree2dBase):
         lookup. Increase this to reduce memory usage at the cost of lookup
         performance.
     tolerance: float, optional, default: 1e-9
-        Tolerance used to build edge bounding boxes. If a point is within
-        this distance from an edge, it is considered to be on the edge.
+        Tolerance used to build edge bounding boxes, which are used to traverse
+        the celltree. Specifying a tolerance is mainly relevant when edges are
+        axis-aligned. 
     """
 
     def __init__(

--- a/numba_celltree/edge_celltree.py
+++ b/numba_celltree/edge_celltree.py
@@ -39,10 +39,13 @@ class EdgeCellTree2d(CellTree2dBase):
         to only 1, but this doubles memory footprint for slightly faster
         lookup. Increase this to reduce memory usage at the cost of lookup
         performance.
-    tolerance: float, optional, default: 1e-9
+    tolerance: float, optional
         Tolerance used to build edge bounding boxes, which are used to traverse
         the celltree. Specifying a tolerance is mainly relevant when edges are
-        axis-aligned.
+        axis-aligned. If None, the method tries to estimate an appropriate
+        tolerance by multiplying the maximum diagonal of the bounding boxes with
+        1e-12.
+
     """
 
     def __init__(
@@ -95,10 +98,13 @@ class EdgeCellTree2d(CellTree2dBase):
         ----------
         points: ndarray of floats with shape ``(n_point, 2)``
             Coordinates of the points to be located.
-        tolerance: float, optional, default: 1e-9
-            The tolerance used to determine whether a point is on an edge.
-            If the distance from the point to the edge is smaller than this
-            value, the point is considered to be on the edge.
+        tolerance: float, optional
+            The tolerance used to determine whether a point is on an edge. If
+            the distance from the point to the edge is smaller than this value,
+            the point is considered to be on the edge. If None, the method tries
+            to estimate an appropriate tolerance by multiplying the maximum
+            diagonal of the bounding boxes with 1e-12.
+
 
         Returns
         -------

--- a/numba_celltree/edge_celltree.py
+++ b/numba_celltree/edge_celltree.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numba as nb
 import numpy as np
@@ -45,8 +45,10 @@ class EdgeCellTree2d(CellTree2dBase):
         edges: IntArray,
         n_buckets: int = 4,
         cells_per_leaf: int = 2,
-        tolerance: float = TOLERANCE_ON_EDGE,
+        tolerance: Optional[float] = None,
     ):
+        if tolerance is None:
+            tolerance = TOLERANCE_ON_EDGE
         if n_buckets < 2:
             raise ValueError("n_buckets must be >= 2")
         if cells_per_leaf < 1:
@@ -75,7 +77,7 @@ class EdgeCellTree2d(CellTree2dBase):
         )
 
     def locate_points(
-        self, points: FloatArray, tolerance: float = TOLERANCE_ON_EDGE
+        self, points: FloatArray, tolerance: Optional[float] = None
     ) -> IntArray:
         """
         Find the index of a face that contains a point.
@@ -95,6 +97,8 @@ class EdgeCellTree2d(CellTree2dBase):
             For every point, the index of the edge it falls on. Points not
             falling on any edge are marked with a value of ``-1``.
         """
+        if tolerance is None:
+            tolerance = TOLERANCE_ON_EDGE
         points = cast_vertices(points)
         return locate_points_on_edge(points, self.celltree_data, tolerance)
 

--- a/numba_celltree/edge_celltree.py
+++ b/numba_celltree/edge_celltree.py
@@ -99,7 +99,7 @@ class EdgeCellTree2d(CellTree2dBase):
         return locate_points_on_edge(points, self.celltree_data, tolerance)
 
     def intersect_edges(
-        self, edge_coords: FloatArray, tolerance: float = TOLERANCE_ON_EDGE
+        self, edge_coords: FloatArray,
     ) -> Tuple[IntArray, IntArray, FloatArray]:
         """
         Find the index of an edge intersecting with an edge.
@@ -108,10 +108,6 @@ class EdgeCellTree2d(CellTree2dBase):
         ----------
         edge_coords: ndarray of floats with shape ``(n_edge, 2, 2)``
             Every row containing ``((x0, y0), (x1, y1))``.
-        tolerance: float, optional, default: 1e-9
-            The tolerance used to determine whether a point is on an edge.
-            If the distance from the point to the edge is smaller than this
-            value, the point is considered to be on the edge.
 
         Returns
         -------
@@ -125,7 +121,7 @@ class EdgeCellTree2d(CellTree2dBase):
         edge_coords = cast_edges(edge_coords)
         n_chunks = nb.get_num_threads()
         edge_indices, tree_edge_indices, xy = locate_edge_edges(
-            edge_coords, self.celltree_data, n_chunks, tolerance
+            edge_coords, self.celltree_data, n_chunks
         )
         intersection_xy = np.ascontiguousarray(xy[:, 0])
         return edge_indices, tree_edge_indices, intersection_xy

--- a/numba_celltree/geometry_utils.py
+++ b/numba_celltree/geometry_utils.py
@@ -184,8 +184,10 @@ def point_in_polygon_or_on_edge(p: Point, poly: FloatArray, tolerance: float) ->
         # if's collinear by checking whether it falls in the bounding box of
         # points v0 and v1.
         A = cross_product(U, V)
-        L2 = V.x * V.x + V.y * V.y
-        # Compute optimized equivalent of A/length < tolerance (no sqrt, no division)
+        W = to_vector(v0, v1)
+        L2 = W.x * W.x + W.y * W.y
+        # Compute optimized equivalent of A/length < tolerance (no sqrt, no
+        # division).
         if (A * A) < (tolerance * tolerance * L2) and in_bounds(p, v0, v1, tolerance):
             return True
 
@@ -207,9 +209,11 @@ def point_on_edge(p: Point, edge: FloatArray, tolerance: float) -> bool:
         return False
     U = to_vector(p, v0)
     V = to_vector(p, v1)
+    W = to_vector(v0, v1)
+    L2 = W.x * W.x + W.y * W.y
     A = cross_product(U, V)
-    L2 = V.x * V.x + V.y * V.y
-    # Compute optimized equivalent of A/length < tolerance (no sqrt, no division)
+    # Compute optimized equivalent of A/length < tolerance (no sqrt, no
+    # division).
     if (A * A) < (tolerance * tolerance * L2) and in_bounds(p, v0, v1, tolerance):
         return True
     return False

--- a/numba_celltree/geometry_utils.py
+++ b/numba_celltree/geometry_utils.py
@@ -7,6 +7,7 @@ from numba_celltree.constants import (
     FILL_VALUE,
     NDIM,
     PARALLEL,
+    TOLERANCE_ON_EDGE,
     Box,
     FloatArray,
     FloatDType,
@@ -14,7 +15,6 @@ from numba_celltree.constants import (
     Point,
     Triangle,
     Vector,
-    TOLERANCE_ON_EDGE,
 )
 from numba_celltree.utils import allocate_box_polygon, allocate_polygon
 
@@ -151,7 +151,7 @@ def in_bounds(p: Point, a: Point, b: Point, tolerance: float) -> bool:
     (dx=0) or horizontal (dy=0) and only evaluate the non-zero value.
     If the area created by p, a, b is tiny AND p is within the bounds of a and
     b, the point lies very close to the edge.
-    
+
     This is a branchless implementation.
     """
     xmin = min(a.x, b.x) - tolerance
@@ -163,7 +163,9 @@ def in_bounds(p: Point, a: Point, b: Point, tolerance: float) -> bool:
     # Determine which bound to use based on which dimension is larger
     use_x_bound = abs(dx) >= abs(dy)
     # Combine results without branching
-    return (use_x_bound and ((p.x >= xmin) and (p.x <= xmax))) or (not use_x_bound and ((p.y >= ymin) and (p.y <= ymax)))
+    return (use_x_bound and ((p.x >= xmin) and (p.x <= xmax))) or (
+        not use_x_bound and ((p.y >= ymin) and (p.y <= ymax))
+    )
 
 
 @nb.njit(inline="always")

--- a/numba_celltree/geometry_utils.py
+++ b/numba_celltree/geometry_utils.py
@@ -142,7 +142,6 @@ def point_in_polygon(p: Point, poly: Sequence) -> bool:
 
 
 @nb.njit(inline="always")
-@nb.njit(inline="always")
 def in_bounds(p: Point, a: Point, b: Point, tolerance: float) -> bool:
     """
     Check whether point p falls within the bounding box created by a and b
@@ -301,7 +300,7 @@ def midpoint_collinear_lines(a: Point, b: Point, p: Point, q: Point) -> Point:
     return midpoint_x, midpoint_y
 
 
-# @nb.njit(inline="always")
+@nb.njit(inline="always")
 def lines_intersect(
     a: Point, b: Point, p: Point, q: Point
 ) -> tuple[bool, float, float]:

--- a/numba_celltree/geometry_utils.py
+++ b/numba_celltree/geometry_utils.py
@@ -188,7 +188,7 @@ def point_in_polygon_or_on_edge(p: Point, poly: FloatArray, tolerance: float) ->
         L2 = W.x * W.x + W.y * W.y
         # Compute optimized equivalent of A/length < tolerance (no sqrt, no
         # division).
-        if (A * A) < (tolerance * tolerance * L2) and in_bounds(p, v0, v1, tolerance):
+        if (A * A) < ((tolerance * L2) * tolerance) and in_bounds(p, v0, v1, tolerance):
             return True
 
         if (v0.y > p.y) != (v1.y > p.y) and p.x < (
@@ -214,7 +214,7 @@ def point_on_edge(p: Point, edge: FloatArray, tolerance: float) -> bool:
     A = cross_product(U, V)
     # Compute optimized equivalent of A/length < tolerance (no sqrt, no
     # division).
-    if (A * A) < (tolerance * tolerance * L2) and in_bounds(p, v0, v1, tolerance):
+    if (A * A) < ((tolerance * L2) * tolerance) and in_bounds(p, v0, v1, tolerance):
         return True
     return False
 

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -384,18 +384,18 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
             node_dim = 1 if node["dim"] else 0
             dx = V[node_dim]
             if dx > 0.0:
-                dx_left = node["Lmax"] - a[node_dim]
-                dx_right = node["Rmin"] - b[node_dim]
+                dx_left = node["Lmax"] - a[node_dim] + tolerance
+                dx_right = node["Rmin"] - b[node_dim] + tolerance
             else:
-                dx_left = node["Lmax"] - b[node_dim]
-                dx_right = node["Rmin"] - a[node_dim]
+                dx_left = node["Lmax"] - b[node_dim] - tolerance
+                dx_right = node["Rmin"] - a[node_dim] - tolerance
 
             # Check how origin (a) and end (b) are located compared to box edges
             # (Lmax, Rmin). The box should be investigated if:
             # * the origin is left of Lmax (dx_left >= 0)
             # * the end is right of Rmin (dx_right <= 0)
-            left = dx_left >= 0.0
-            right = dx_right <= 0.0
+            left = dx_left >= -tolerance
+            right = dx_right <= tolerance
 
             # Now find the intersection coordinates. These have to occur within in
             # the bounds of the vector. Note that if the line has no slope in this
@@ -404,17 +404,17 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
             if dx > 0.0:  # TODO: abs(dx) > EPISLON?
                 if left:
                     t_left = dx_left / dx
-                    left = t_left >= 0.0
+                    left = t_left >= -tolerance
                 if right:
                     t_right = dx_right / dx
-                    right = t_right <= 1.0
+                    right = t_right <= (1.0 + tolerance)
             elif dx < 0.0:
                 if left:
                     t_left = 1.0 - (dx_left / dx)
-                    left = t_left >= 0.0
+                    left = t_left >= -tolerance
                 if right:
                     t_right = 1.0 - (dx_right / dx)
-                    right = t_right <= 1.0
+                    right = t_right <= (1.0 + tolerance)
             # else dx == 0.0. In this case there's no info to extract from this
             # node. We'll fully defer to the children.
             left_child = node["child"]

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -83,15 +83,15 @@ def locate_point(point: Point, tree: CellTreeData, tolerance: float):
             continue
 
         dim = 1 if node["dim"] else 0
-        left = point[dim] <= node["Lmax"]
-        right = point[dim] >= node["Rmin"]
+        left = point[dim] <= (node["Lmax"] + tolerance)
+        right = point[dim] >= (node["Rmin"] - tolerance)
         left_child = node["child"]
         right_child = left_child + 1
 
         if left and right:
             # This heuristic is worthwhile because a point will fall into a
             # single face -- if found, we can stop.
-            if (node["Lmax"] - point[dim]) < (point[dim] - node["Rmin"]):
+            if (node["Lmax"] - point[dim]) < (point[dim] - node["Rmin"] + tolerance):
                 stack, size = push(stack, left_child, size)
                 stack, size = push(stack, right_child, size)
             else:

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -327,7 +327,7 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
     # probably also a rather bad idea, given its complexity: compared to looking
     # for either boxes or points, checking is more much complicated by involving
     # two intersection algorithms.
-    #    @nb.njit(inline="never")
+    @nb.njit(inline="never")
     def locate_edge(
         a: Point,
         b: Point,
@@ -426,7 +426,7 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
 
         return count, indices_size
 
-    #    @nb.njit(cache=True)
+    @nb.njit(cache=True)
     def locate_edges_helper(
         edge_coords: FloatArray,
         tree: CellTreeData,
@@ -465,7 +465,7 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
 
         return indices, xy, total_count
 
-    #    @nb.njit(cache=True, parallel=PARALLEL)
+    @nb.njit(cache=True, parallel=PARALLEL)
     def locate_edges(box_coords: FloatArray, tree: CellTreeData, n_chunks: int):
         chunks = np.array_split(box_coords, n_chunks)
         offsets = np.zeros(n_chunks, dtype=IntDType)

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -66,6 +66,9 @@ def locate_point(point: Point, tree: CellTreeData, tolerance: float):
     return_value = -1
     size = 1
 
+    point_left = Point(point[0] - tolerance, point[1] - tolerance)
+    point_right = Point(point[0] + tolerance, point[1] + tolerance)
+
     while size > 0:
         node_index, size = pop(stack, size)
         node = tree.nodes[node_index]
@@ -83,15 +86,15 @@ def locate_point(point: Point, tree: CellTreeData, tolerance: float):
             continue
 
         dim = 1 if node["dim"] else 0
-        left = point[dim] <= (node["Lmax"] + tolerance)
-        right = point[dim] >= (node["Rmin"] - tolerance)
+        left = point_left[dim] <= node["Lmax"]
+        right = point_right[dim] >= node["Rmin"]
         left_child = node["child"]
         right_child = left_child + 1
 
         if left and right:
             # This heuristic is worthwhile because a point will fall into a
             # single face -- if found, we can stop.
-            if (node["Lmax"] - point[dim]) < (point[dim] - node["Rmin"] + tolerance):
+            if (node["Lmax"] - point[dim]) < (point_right[dim] - node["Rmin"]):
                 stack, size = push(stack, left_child, size)
                 stack, size = push(stack, right_child, size)
             else:
@@ -125,6 +128,9 @@ def locate_point_on_edge(point: Point, tree: CellTreeData, tolerance: float):
     # TODO: Rename allocate_polygon or assess if we can allocate a smaller array.
     edge_work_array = allocate_polygon()
 
+    point_left = Point(point[0] - tolerance, point[1] - tolerance)
+    point_right = Point(point[0] + tolerance, point[1] + tolerance)
+
     while size > 0:
         node_index, size = pop(stack, size)
         node = tree.nodes[node_index]
@@ -140,15 +146,15 @@ def locate_point_on_edge(point: Point, tree: CellTreeData, tolerance: float):
             continue
 
         dim = 1 if node["dim"] else 0
-        left = point[dim] <= node["Lmax"]
-        right = point[dim] >= node["Rmin"]
+        left = point_left[dim] <= node["Lmax"]
+        right = point_right[dim] >= node["Rmin"]
         left_child = node["child"]
         right_child = left_child + 1
 
         if left and right:
             # This heuristic is worthwhile because a point will fall into a
             # single face -- if found, we can stop.
-            if (node["Lmax"] - point[dim]) < (point[dim] - node["Rmin"]):
+            if (node["Lmax"] - point[dim]) < (point_right[dim] - node["Rmin"]):
                 stack, size = push(stack, left_child, size)
                 stack, size = push(stack, right_child, size)
             else:

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -287,7 +287,7 @@ def locate_boxes(box_coords: FloatArray, tree: CellTreeData, n_chunks: int):
     return concatenate_indices(indices, counts)
 
 
-# @nb.njit(inline="always")
+@nb.njit(inline="always")
 def compute_edge_edge_intersect(
     tree: CellTreeData,
     bbox_index: int,

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -403,14 +403,14 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
                     left = t_left >= 0.0
                 if right:
                     t_right = dx_right / dx
-                    right = t_right <= (1.0)
+                    right = t_right <= 1.0
             elif dx < 0.0:
                 if left:
                     t_left = 1.0 - (dx_left / dx)
                     left = t_left >= 0.0
                 if right:
                     t_right = 1.0 - (dx_right / dx)
-                    right = t_right <= (1.0)
+                    right = t_right <= 1.0
             # else dx == 0.0. In this case there's no info to extract from this
             # node. We'll fully defer to the children.
             left_child = node["child"]

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -300,7 +300,7 @@ def compute_edge_edge_intersect(
     vertices = tree.vertices[tree_edge]
     p = as_point(vertices[0])
     q = as_point(vertices[1])
-    intersects, x, y = lines_intersect(a, b, p, q)
+    intersects, x, y = lines_intersect(a, b, p, q, tolerance)
     c = Point(x, y)
     return intersects, c, c
 

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -327,7 +327,7 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
     # probably also a rather bad idea, given its complexity: compared to looking
     # for either boxes or points, checking is more much complicated by involving
     # two intersection algorithms.
-#    @nb.njit(inline="never")
+    #    @nb.njit(inline="never")
     def locate_edge(
         a: Point,
         b: Point,
@@ -426,7 +426,7 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
 
         return count, indices_size
 
-#    @nb.njit(cache=True)
+    #    @nb.njit(cache=True)
     def locate_edges_helper(
         edge_coords: FloatArray,
         tree: CellTreeData,
@@ -465,10 +465,8 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
 
         return indices, xy, total_count
 
-#    @nb.njit(cache=True, parallel=PARALLEL)
-    def locate_edges(
-        box_coords: FloatArray, tree: CellTreeData, n_chunks: int
-    ):
+    #    @nb.njit(cache=True, parallel=PARALLEL)
+    def locate_edges(box_coords: FloatArray, tree: CellTreeData, n_chunks: int):
         chunks = np.array_split(box_coords, n_chunks)
         offsets = np.zeros(n_chunks, dtype=IntDType)
         for i, chunk in enumerate(chunks[:-1]):
@@ -480,7 +478,9 @@ def make_locate_edges(intersection_function: nb.types.Callable) -> nb.types.Call
         counts = np.empty(n_chunks, dtype=IntDType)
         for i in nb.prange(n_chunks):
             indices[i], intersections[i], counts[i] = locate_edges_helper(
-                chunks[i], tree, offsets[i],
+                chunks[i],
+                tree,
+                offsets[i],
             )
 
         total_size = sum(counts)

--- a/numba_celltree/query.py
+++ b/numba_celltree/query.py
@@ -8,7 +8,9 @@ from numba_celltree.algorithms import (
     cyrus_beck_line_polygon_clip,
 )
 from numba_celltree.constants import (
+    MIN_TOLERANCE,
     PARALLEL,
+    TOLERANCE_FACTOR,
     BoolArray,
     CellTreeData,
     FloatArray,
@@ -324,7 +326,11 @@ def compute_edge_face_intersect(
         polygon = copy_vertices_into(
             tree.vertices, tree.elements[bbox_index], work_array
         )
-        intersects, c, d = cyrus_beck_line_polygon_clip(a, b, polygon)
+        tolerance = max(
+            MIN_TOLERANCE,
+            TOLERANCE_FACTOR * max(box.xmax - box.xmin, box.ymax - box.ymin),
+        )
+        intersects, c, d = cyrus_beck_line_polygon_clip(a, b, polygon, tolerance)
     return intersects, c, d
 
 

--- a/tests/test_algorithms/test_barycentric.py
+++ b/tests/test_algorithms/test_barycentric.py
@@ -3,7 +3,9 @@ import pytest
 
 from numba_celltree.algorithms import barycentric_triangle as bt
 from numba_celltree.algorithms import barycentric_wachspress as bwp
-from numba_celltree.constants import TOLERANCE_ON_EDGE, Point, Triangle, Vector
+from numba_celltree.constants import Point, Triangle, Vector
+
+TOLERANCE_ON_EDGE = 1e-9
 
 
 def test_interp_edge_case():

--- a/tests/test_algorithms/test_barycentric.py
+++ b/tests/test_algorithms/test_barycentric.py
@@ -3,7 +3,7 @@ import pytest
 
 from numba_celltree.algorithms import barycentric_triangle as bt
 from numba_celltree.algorithms import barycentric_wachspress as bwp
-from numba_celltree.constants import Point, Triangle, Vector
+from numba_celltree.constants import TOLERANCE_ON_EDGE, Point, Triangle, Vector
 
 
 def test_interp_edge_case():
@@ -84,14 +84,16 @@ def test_barycentric_triangle_weights(barycentric_weights):
             [0.0, 0.0, 0.0],
         ]
     )
-    actual = barycentric_weights(points, face_indices, faces, vertices)
+    actual = barycentric_weights(
+        points, face_indices, faces, vertices, TOLERANCE_ON_EDGE
+    )
     assert np.allclose(actual, expected)
 
 
 def test_compute_weights_wachspress():
     def compute(polygon, point):
         weights = np.zeros(4)
-        bwp.compute_weights(polygon, point, weights)
+        bwp.compute_weights(polygon, point, weights, TOLERANCE_ON_EDGE)
         return weights
 
     polygon = np.array(
@@ -150,5 +152,7 @@ def test_barycentric_wachspress_weights():
             [0.0, 0.0, 0.0, 0.0],
         ]
     )
-    actual = bwp.barycentric_wachspress_weights(points, face_indices, faces, vertices)
+    actual = bwp.barycentric_wachspress_weights(
+        points, face_indices, faces, vertices, TOLERANCE_ON_EDGE
+    )
     assert np.allclose(actual, expected)

--- a/tests/test_algorithms/test_line_box_clip.py
+++ b/tests/test_algorithms/test_line_box_clip.py
@@ -14,6 +14,16 @@ def ab(a, b, c):
     return (a, c, b)
 
 
+TOLERANCE = 1e-9
+
+
+def wraptol(function):
+    def f(a, b, poly):
+        return function(a, b, poly, TOLERANCE)
+
+    return f
+
+
 BOX = Box(0.0, 2.0, 0.0, 2.0)
 POLY = np.array(
     [
@@ -31,7 +41,7 @@ POLY_REVERSED = POLY[::-1, :]
     [
         (cohen_sutherland_line_box_clip, BOX),
         (liang_barsky_line_box_clip, BOX),
-        (cyrus_beck_line_polygon_clip, POLY),
+        (wraptol(cyrus_beck_line_polygon_clip), POLY),
     ],
 )
 def test_line_box_clip(line_clip, box):
@@ -114,8 +124,8 @@ def test_line_box_clip(line_clip, box):
     [
         (cohen_sutherland_line_box_clip, BOX),
         (liang_barsky_line_box_clip, BOX),
-        (cyrus_beck_line_polygon_clip, POLY),
-        (cyrus_beck_line_polygon_clip, POLY_REVERSED),
+        (wraptol(cyrus_beck_line_polygon_clip), POLY),
+        (wraptol(cyrus_beck_line_polygon_clip), POLY_REVERSED),
     ],
 )
 def test_line_box_clip_degeneracy(line_clip, box):

--- a/tests/test_algorithms/test_line_box_clip.py
+++ b/tests/test_algorithms/test_line_box_clip.py
@@ -6,7 +6,7 @@ from numba_celltree.algorithms import (
     cyrus_beck_line_polygon_clip,
     liang_barsky_line_box_clip,
 )
-from numba_celltree.constants import TOLERANCE_ON_EDGE, Box, Point
+from numba_celltree.constants import Box, Point
 
 
 def ab(a, b, c):

--- a/tests/test_algorithms/test_line_box_clip.py
+++ b/tests/test_algorithms/test_line_box_clip.py
@@ -27,63 +27,63 @@ POLY_REVERSED = POLY[::-1, :]
 
 
 @pytest.mark.parametrize(
-    "line_clip, args",
+    "line_clip, box",
     [
-        (cohen_sutherland_line_box_clip, (BOX,)),
-        (liang_barsky_line_box_clip, (BOX,)),
-        (cyrus_beck_line_polygon_clip, (POLY,)),
+        (cohen_sutherland_line_box_clip, BOX),
+        (liang_barsky_line_box_clip, BOX),
+        (cyrus_beck_line_polygon_clip, POLY),
     ],
 )
-def test_line_box_clip(line_clip, args):
+def test_line_box_clip(line_clip, box):
     a = Point(-1.0, 0.0)
     b = Point(2.0, 3.0)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert intersects
     assert np.allclose(c, [0.0, 1.0])
     assert np.allclose(d, [1.0, 2.0])
 
     a = Point(0.0, -0.1)
     b = Point(0.0, -0.1)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert not intersects
     assert np.isnan(c).all()
     assert np.isnan(d).all()
 
     a = Point(-1.0, 1.0)
     b = Point(3.0, 1.0)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert intersects
     assert np.allclose(c, [0.0, 1.0])
     assert np.allclose(d, [2.0, 1.0])
 
     a = Point(1.0, -3.0)
     b = Point(1.0, 3.0)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert intersects
     assert np.allclose(c, [1.0, 0.0])
     assert np.allclose(d, [1.0, 2.0])
 
     b = Point(1.0, 1.0)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert intersects
     assert np.allclose(c, [1.0, 0.0])
     assert np.allclose(d, [1.0, 1.0])
 
     a = Point(1.0, 1.0)
     b = Point(1.0, 3.0)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert intersects
     assert np.allclose(c, [1.0, 1.0])
     assert np.allclose(d, [1.0, 2.0])
 
     a = Point(-1.0, 3.0)
     b = Point(3.0, 3.0)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert not intersects
 
     a = Point(-1.0, 1.0)
     b = Point(1.0, 1.0)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert intersects
     assert np.allclose(c, [0.0, 1.0])
     assert np.allclose(d, [1.0, 1.0])
@@ -91,7 +91,7 @@ def test_line_box_clip(line_clip, args):
     # both inside
     a = Point(0.5, 0.5)
     b = Point(1.5, 1.5)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert intersects
     assert np.allclose(c, a)
     assert np.allclose(d, b)
@@ -99,26 +99,26 @@ def test_line_box_clip(line_clip, args):
     # No intersection, left
     a = Point(-1.5, 0.0)
     b = Point(-0.5, 1.0)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert not intersects
 
     # No intersection, right
     a = Point(2.5, 0.0)
     b = Point(3.5, 1.0)
-    intersects, c, d = line_clip(a, b, *args)
+    intersects, c, d = line_clip(a, b, box)
     assert not intersects
 
 
 @pytest.mark.parametrize(
-    "line_clip, args",
+    "line_clip, box",
     [
-        (cohen_sutherland_line_box_clip, (BOX,)),
-        (liang_barsky_line_box_clip, (BOX,)),
-        (cyrus_beck_line_polygon_clip, (POLY,)),
-        (cyrus_beck_line_polygon_clip, (POLY_REVERSED,)),
+        (cohen_sutherland_line_box_clip, BOX),
+        (liang_barsky_line_box_clip, BOX),
+        (cyrus_beck_line_polygon_clip, POLY),
+        (cyrus_beck_line_polygon_clip, POLY_REVERSED),
     ],
 )
-def test_line_box_clip_degeneracy(line_clip, args):
+def test_line_box_clip_degeneracy(line_clip, box):
     def assert_expected(
         a: tuple,
         b: tuple,
@@ -129,7 +129,7 @@ def test_line_box_clip_degeneracy(line_clip, args):
         a = Point(*a)
         b = Point(*b)
         # c, d are the clipped points
-        actual, actual_c, actual_d = line_clip(a, b, *args)
+        actual, actual_c, actual_d = line_clip(a, b, box)
         print(actual_c, c)
         print(actual_d, d)
         assert intersects is actual
@@ -137,7 +137,7 @@ def test_line_box_clip_degeneracy(line_clip, args):
         assert np.allclose(actual_d, d, equal_nan=True)
 
         # Direction of the point doesn't change, so neither should the answer.
-        actual, actual_c, actual_d = line_clip(a, b, *args)
+        actual, actual_c, actual_d = line_clip(a, b, box)
         assert intersects is actual
         assert np.allclose(actual_c, c, equal_nan=True)
         assert np.allclose(actual_d, d, equal_nan=True)

--- a/tests/test_algorithms/test_line_box_clip.py
+++ b/tests/test_algorithms/test_line_box_clip.py
@@ -31,7 +31,7 @@ POLY_REVERSED = POLY[::-1, :]
     [
         (cohen_sutherland_line_box_clip, (BOX,)),
         (liang_barsky_line_box_clip, (BOX,)),
-        (cyrus_beck_line_polygon_clip, (POLY, TOLERANCE_ON_EDGE)),
+        (cyrus_beck_line_polygon_clip, (POLY,)),
     ],
 )
 def test_line_box_clip(line_clip, args):
@@ -114,8 +114,8 @@ def test_line_box_clip(line_clip, args):
     [
         (cohen_sutherland_line_box_clip, (BOX,)),
         (liang_barsky_line_box_clip, (BOX,)),
-        (cyrus_beck_line_polygon_clip, (POLY, TOLERANCE_ON_EDGE)),
-        (cyrus_beck_line_polygon_clip, (POLY_REVERSED, TOLERANCE_ON_EDGE)),
+        (cyrus_beck_line_polygon_clip, (POLY,)),
+        (cyrus_beck_line_polygon_clip, (POLY_REVERSED,)),
     ],
 )
 def test_line_box_clip_degeneracy(line_clip, args):

--- a/tests/test_algorithms/test_line_polygon_clip.py
+++ b/tests/test_algorithms/test_line_polygon_clip.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-from numba_celltree.algorithms import cyrus_beck_line_polygon_clip as line_clip
 from numba_celltree.algorithms.cyrus_beck import cyrus_beck_line_polygon_clip
 from numba_celltree.constants import Point
 
@@ -10,6 +9,13 @@ from numba_celltree.constants import Point
 def ab(a, b, c):
     """Flip the result around to compare (a, b) with (b, a)"""
     return (a, c, b)
+
+
+TOLERANCE = 1e-9
+
+
+def line_clip(a, b, poly):
+    return cyrus_beck_line_polygon_clip(a, b, poly, TOLERANCE)
 
 
 def test_line_box_clip():
@@ -183,7 +189,7 @@ def test_line_box_degeneracies():
     poly = nodes[faces[1]]
     a = Point(1.0, 1.0)
     b = Point(1.5, 1.25)
-    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly)
+    succes, c, d = line_clip(a, b, poly)
     assert succes
     assert c == Point(1.0, 1.0)
     assert d == Point(1.5, 1.25)
@@ -192,7 +198,7 @@ def test_line_box_degeneracies():
         poly = nodes[faces[i]]
         a = Point(1.0, 1.0)
         b = Point(1.5, 1.25)
-        succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly)
+        succes, c, d = line_clip(a, b, poly)
         assert not succes
 
     # This is a case where a is inside, but b is right on the vertex
@@ -203,7 +209,7 @@ def test_line_box_degeneracies():
     poly = nodes[faces[2]]
     a = Point(0.5, 0.75)
     b = Point(1.0, 1.0)
-    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly)
+    succes, c, d = line_clip(a, b, poly)
     assert succes
     assert c == a
     assert d == b

--- a/tests/test_algorithms/test_line_polygon_clip.py
+++ b/tests/test_algorithms/test_line_polygon_clip.py
@@ -4,9 +4,7 @@ import numpy as np
 
 from numba_celltree.algorithms import cyrus_beck_line_polygon_clip as line_clip
 from numba_celltree.algorithms.cyrus_beck import cyrus_beck_line_polygon_clip
-from numba_celltree.constants import TOLERANCE_ON_EDGE, Point
-
-TOL = TOLERANCE_ON_EDGE
+from numba_celltree.constants import Point
 
 
 def ab(a, b, c):

--- a/tests/test_algorithms/test_line_polygon_clip.py
+++ b/tests/test_algorithms/test_line_polygon_clip.py
@@ -4,7 +4,9 @@ import numpy as np
 
 from numba_celltree.algorithms import cyrus_beck_line_polygon_clip as line_clip
 from numba_celltree.algorithms.cyrus_beck import cyrus_beck_line_polygon_clip
-from numba_celltree.constants import Point
+from numba_celltree.constants import TOLERANCE_ON_EDGE, Point
+
+TOL = TOLERANCE_ON_EDGE
 
 
 def ab(a, b, c):
@@ -24,27 +26,27 @@ def test_line_box_clip():
 
     a = Point(0.0, 0.0)
     b = Point(4.0, 6.0)
-    intersects, c, d = line_clip(a, b, poly)
+    intersects, c, d = line_clip(a, b, poly, TOL)
     assert intersects
     assert np.allclose(c, [2.0, 3.0])
     assert np.allclose(d, [3.3333333333333, 5.0])
-    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
+    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
 
     a = Point(0.0, 0.1)
     b = Point(0.0, 0.1)
-    intersects, c, d = line_clip(a, b, poly)
+    intersects, c, d = line_clip(a, b, poly, TOL)
     assert not intersects
     assert np.isnan(c).all()
     assert np.isnan(d).all()
-    assert line_clip(a, b, poly)[0] == line_clip(b, a, poly)[0]
+    assert line_clip(a, b, poly, TOL)[0] == line_clip(b, a, poly, TOL)[0]
 
     a = Point(0.0, 4.0)
     b = Point(5.0, 4.0)
-    intersects, c, d = line_clip(a, b, poly)
+    intersects, c, d = line_clip(a, b, poly, TOL)
     assert intersects
     assert np.allclose(c, [1.0, 4.0])
     assert np.allclose(d, [4.0, 4.0])
-    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
+    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
 
     poly = np.array(
         [
@@ -56,33 +58,33 @@ def test_line_box_clip():
     )
     a = Point(1.0, -3.0)
     b = Point(1.0, 3.0)
-    intersects, c, d = line_clip(a, b, poly)
+    intersects, c, d = line_clip(a, b, poly, TOL)
     assert intersects
     assert np.allclose(c, [1.0, 0.0])
     assert np.allclose(d, [1.0, 2.0])
-    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
+    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
 
     b = Point(1.0, 1.0)
-    intersects, c, d = line_clip(a, b, poly)
+    intersects, c, d = line_clip(a, b, poly, TOL)
     assert intersects
     assert np.allclose(c, [1.0, 0.0])
     assert np.allclose(d, [1.0, 1.0])
-    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
+    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
 
     a = Point(1.0, 1.0)
     b = Point(1.0, 3.0)
-    intersects, c, d = line_clip(a, b, poly)
+    intersects, c, d = line_clip(a, b, poly, TOL)
     assert intersects
     assert np.allclose(c, [1.0, 1.0])
     assert np.allclose(d, [1.0, 2.0])
-    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
+    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
 
 
 def test_line_box_clip_through_vertex():
     a = Point(x=2.0, y=2.0)
     b = Point(x=1.0, y=4.0)
     poly = np.array([[2.0, 4.0], [1.0, 4.0], [1.0, 3.0], [2.0, 3.0]])
-    intersects, c, d = line_clip(a, b, poly)
+    intersects, c, d = line_clip(a, b, poly, TOL)
     assert intersects
     assert np.allclose(c, [1.5, 3.0])
     assert np.allclose(d, [1.0, 4.0])
@@ -90,11 +92,11 @@ def test_line_box_clip_through_vertex():
     a = Point(x=2.0, y=0.0)
     b = Point(x=2.0, y=2.0)
     poly = np.array([[2.0, 3.0], [1.0, 3.0], [1.0, 2.0], [2.0, 2.0]])
-    intersects, _, _ = line_clip(a, b, poly)
+    intersects, _, _ = line_clip(a, b, poly, TOL)
     assert not intersects
 
     poly = np.array([[3.0, 3.0], [2.0, 3.0], [2.0, 2.0], [3.0, 2.0]])
-    intersects, c, d = line_clip(a, b, poly)
+    intersects, c, d = line_clip(a, b, poly, TOL)
     assert not intersects
 
 
@@ -109,11 +111,11 @@ def test_line_triangle_clip():
             [2.0, 2.0],
         ]
     )
-    intersects, c, d = line_clip(a, b, poly)
+    intersects, c, d = line_clip(a, b, poly, TOL)
     assert intersects
     assert np.allclose(c, [1.0, 1.0])
     assert np.allclose(d, [2.0, 1.0])
-    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
+    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
 
 
 def test_line_triangle_clip_degeneracies():
@@ -127,35 +129,35 @@ def test_line_triangle_clip_degeneracies():
     # Lower edge
     a = Point(0.0, 0.0)
     b = Point(2.0, 0.0)
-    assert line_clip(a, b, poly)[0]
-    assert line_clip(b, a, poly)[0]
+    assert line_clip(a, b, poly, TOL)[0]
+    assert line_clip(b, a, poly, TOL)[0]
 
     # Right edge
     a = Point(2.0, 0.0)
     b = Point(2.0, 2.0)
-    assert line_clip(a, b, poly)[0]
-    assert line_clip(b, a, poly)[0]
+    assert line_clip(a, b, poly, TOL)[0]
+    assert line_clip(b, a, poly, TOL)[0]
 
     # Diagonal edge
     a = Point(0.0, 0.0)
     b = Point(2.0, 2.0)
-    assert line_clip(a, b, poly)[0]
-    assert line_clip(b, a, poly)[0]
+    assert line_clip(a, b, poly, TOL)[0]
+    assert line_clip(b, a, poly, TOL)[0]
 
     a = Point(-1.0, -1.0)
     b = Point(2.0, 2.0)
-    assert line_clip(a, b, poly)[0]
-    assert line_clip(b, a, poly)[0]
+    assert line_clip(a, b, poly, TOL)[0]
+    assert line_clip(b, a, poly, TOL)[0]
 
     a = Point(-1.0, -1.0)
     b = Point(3.0, 3.0)
-    assert line_clip(a, b, poly)[0]
-    assert line_clip(b, a, poly)[0]
+    assert line_clip(a, b, poly, TOL)[0]
+    assert line_clip(b, a, poly, TOL)[0]
 
     a = Point(0.0, 0.0)
     b = Point(3.0, 3.0)
-    assert line_clip(a, b, poly)[0]
-    assert line_clip(b, a, poly)[0]
+    assert line_clip(a, b, poly, TOL)[0]
+    assert line_clip(b, a, poly, TOL)[0]
 
 
 def test_line_box_degeneracies():
@@ -183,7 +185,7 @@ def test_line_box_degeneracies():
     poly = nodes[faces[1]]
     a = Point(1.0, 1.0)
     b = Point(1.5, 1.25)
-    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly)
+    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly, TOL)
     assert succes
     assert c == Point(1.0, 1.0)
     assert d == Point(1.5, 1.25)
@@ -192,18 +194,18 @@ def test_line_box_degeneracies():
         poly = nodes[faces[i]]
         a = Point(1.0, 1.0)
         b = Point(1.5, 1.25)
-        succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly)
+        succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly, TOL)
         assert not succes
 
     # This is a case where a is inside, but b is right on the vertex
-    # point_in_poly(a, poly) == True
-    # point_in_poly(b, poly) == False
+    # point_in_poly(a, poly, TOL) == True
+    # point_in_poly(b, poly, TOL) == False
     # This results in t0 == t1 in Cyrus-Beck. However, we can get the right
     # by setting t0 to 0.0 if a_inside, or t1 to 1.0 if b_inside.
     poly = nodes[faces[2]]
     a = Point(0.5, 0.75)
     b = Point(1.0, 1.0)
-    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly)
+    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly, TOL)
     assert succes
     assert c == a
     assert d == b

--- a/tests/test_algorithms/test_line_polygon_clip.py
+++ b/tests/test_algorithms/test_line_polygon_clip.py
@@ -26,27 +26,27 @@ def test_line_box_clip():
 
     a = Point(0.0, 0.0)
     b = Point(4.0, 6.0)
-    intersects, c, d = line_clip(a, b, poly, TOL)
+    intersects, c, d = line_clip(a, b, poly)
     assert intersects
     assert np.allclose(c, [2.0, 3.0])
     assert np.allclose(d, [3.3333333333333, 5.0])
-    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
+    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
 
     a = Point(0.0, 0.1)
     b = Point(0.0, 0.1)
-    intersects, c, d = line_clip(a, b, poly, TOL)
+    intersects, c, d = line_clip(a, b, poly)
     assert not intersects
     assert np.isnan(c).all()
     assert np.isnan(d).all()
-    assert line_clip(a, b, poly, TOL)[0] == line_clip(b, a, poly, TOL)[0]
+    assert line_clip(a, b, poly)[0] == line_clip(b, a, poly)[0]
 
     a = Point(0.0, 4.0)
     b = Point(5.0, 4.0)
-    intersects, c, d = line_clip(a, b, poly, TOL)
+    intersects, c, d = line_clip(a, b, poly)
     assert intersects
     assert np.allclose(c, [1.0, 4.0])
     assert np.allclose(d, [4.0, 4.0])
-    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
+    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
 
     poly = np.array(
         [
@@ -58,33 +58,33 @@ def test_line_box_clip():
     )
     a = Point(1.0, -3.0)
     b = Point(1.0, 3.0)
-    intersects, c, d = line_clip(a, b, poly, TOL)
+    intersects, c, d = line_clip(a, b, poly)
     assert intersects
     assert np.allclose(c, [1.0, 0.0])
     assert np.allclose(d, [1.0, 2.0])
-    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
+    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
 
     b = Point(1.0, 1.0)
-    intersects, c, d = line_clip(a, b, poly, TOL)
+    intersects, c, d = line_clip(a, b, poly)
     assert intersects
     assert np.allclose(c, [1.0, 0.0])
     assert np.allclose(d, [1.0, 1.0])
-    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
+    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
 
     a = Point(1.0, 1.0)
     b = Point(1.0, 3.0)
-    intersects, c, d = line_clip(a, b, poly, TOL)
+    intersects, c, d = line_clip(a, b, poly)
     assert intersects
     assert np.allclose(c, [1.0, 1.0])
     assert np.allclose(d, [1.0, 2.0])
-    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
+    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
 
 
 def test_line_box_clip_through_vertex():
     a = Point(x=2.0, y=2.0)
     b = Point(x=1.0, y=4.0)
     poly = np.array([[2.0, 4.0], [1.0, 4.0], [1.0, 3.0], [2.0, 3.0]])
-    intersects, c, d = line_clip(a, b, poly, TOL)
+    intersects, c, d = line_clip(a, b, poly)
     assert intersects
     assert np.allclose(c, [1.5, 3.0])
     assert np.allclose(d, [1.0, 4.0])
@@ -92,11 +92,11 @@ def test_line_box_clip_through_vertex():
     a = Point(x=2.0, y=0.0)
     b = Point(x=2.0, y=2.0)
     poly = np.array([[2.0, 3.0], [1.0, 3.0], [1.0, 2.0], [2.0, 2.0]])
-    intersects, _, _ = line_clip(a, b, poly, TOL)
+    intersects, _, _ = line_clip(a, b, poly)
     assert not intersects
 
     poly = np.array([[3.0, 3.0], [2.0, 3.0], [2.0, 2.0], [3.0, 2.0]])
-    intersects, c, d = line_clip(a, b, poly, TOL)
+    intersects, c, d = line_clip(a, b, poly)
     assert not intersects
 
 
@@ -111,11 +111,11 @@ def test_line_triangle_clip():
             [2.0, 2.0],
         ]
     )
-    intersects, c, d = line_clip(a, b, poly, TOL)
+    intersects, c, d = line_clip(a, b, poly)
     assert intersects
     assert np.allclose(c, [1.0, 1.0])
     assert np.allclose(d, [2.0, 1.0])
-    assert line_clip(a, b, poly, TOL) == ab(*line_clip(b, a, poly, TOL))
+    assert line_clip(a, b, poly) == ab(*line_clip(b, a, poly))
 
 
 def test_line_triangle_clip_degeneracies():
@@ -129,35 +129,35 @@ def test_line_triangle_clip_degeneracies():
     # Lower edge
     a = Point(0.0, 0.0)
     b = Point(2.0, 0.0)
-    assert line_clip(a, b, poly, TOL)[0]
-    assert line_clip(b, a, poly, TOL)[0]
+    assert line_clip(a, b, poly)[0]
+    assert line_clip(b, a, poly)[0]
 
     # Right edge
     a = Point(2.0, 0.0)
     b = Point(2.0, 2.0)
-    assert line_clip(a, b, poly, TOL)[0]
-    assert line_clip(b, a, poly, TOL)[0]
+    assert line_clip(a, b, poly)[0]
+    assert line_clip(b, a, poly)[0]
 
     # Diagonal edge
     a = Point(0.0, 0.0)
     b = Point(2.0, 2.0)
-    assert line_clip(a, b, poly, TOL)[0]
-    assert line_clip(b, a, poly, TOL)[0]
+    assert line_clip(a, b, poly)[0]
+    assert line_clip(b, a, poly)[0]
 
     a = Point(-1.0, -1.0)
     b = Point(2.0, 2.0)
-    assert line_clip(a, b, poly, TOL)[0]
-    assert line_clip(b, a, poly, TOL)[0]
+    assert line_clip(a, b, poly)[0]
+    assert line_clip(b, a, poly)[0]
 
     a = Point(-1.0, -1.0)
     b = Point(3.0, 3.0)
-    assert line_clip(a, b, poly, TOL)[0]
-    assert line_clip(b, a, poly, TOL)[0]
+    assert line_clip(a, b, poly)[0]
+    assert line_clip(b, a, poly)[0]
 
     a = Point(0.0, 0.0)
     b = Point(3.0, 3.0)
-    assert line_clip(a, b, poly, TOL)[0]
-    assert line_clip(b, a, poly, TOL)[0]
+    assert line_clip(a, b, poly)[0]
+    assert line_clip(b, a, poly)[0]
 
 
 def test_line_box_degeneracies():
@@ -185,7 +185,7 @@ def test_line_box_degeneracies():
     poly = nodes[faces[1]]
     a = Point(1.0, 1.0)
     b = Point(1.5, 1.25)
-    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly, TOL)
+    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly)
     assert succes
     assert c == Point(1.0, 1.0)
     assert d == Point(1.5, 1.25)
@@ -194,18 +194,18 @@ def test_line_box_degeneracies():
         poly = nodes[faces[i]]
         a = Point(1.0, 1.0)
         b = Point(1.5, 1.25)
-        succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly, TOL)
+        succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly)
         assert not succes
 
     # This is a case where a is inside, but b is right on the vertex
-    # point_in_poly(a, poly, TOL) == True
-    # point_in_poly(b, poly, TOL) == False
+    # point_in_poly(a, poly) == True
+    # point_in_poly(b, poly) == False
     # This results in t0 == t1 in Cyrus-Beck. However, we can get the right
     # by setting t0 to 0.0 if a_inside, or t1 to 1.0 if b_inside.
     poly = nodes[faces[2]]
     a = Point(0.5, 0.75)
     b = Point(1.0, 1.0)
-    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly, TOL)
+    succes, c, d = cyrus_beck_line_polygon_clip(a, b, poly)
     assert succes
     assert c == a
     assert d == b

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -294,15 +294,24 @@ def test_multi_poly_lookup():
     # Test with a point that is very close to the edge of a cell
     point = np.array(
         [
-            [-9e-9, 1.0],
-            [1.0, -9e-9],
+            [-9e-9, 0.0],  # On vertex
+            [2.0, -9e-9],  # On vertex
+            [-9e-9, 1.0],  # On edge
+            [1.0, -9e-9],  # On edge
+            [-1.1e-8, 1.0],  # Outside, very close to edge
+            [1.0, -1.1e-8],  # Outside, very close to edge
+            [-1.1e-8, 0.0],  # Outside, very close to vertex
+            [
+                2.0,
+                -1.5e-8,
+            ],  # Outside, very close to vertex (for some reason y = -1.1e-8 is still considered inside)
         ]
     )
     result = tree.locate_points(point)
-    expected = np.array([-1, -1])
+    expected = np.array([-1, -1, -1, -1, -1, -1, -1, -1])
     assert np.array_equal(result, expected)
     result = tree.locate_points(point, tolerance=1e-8)
-    expected = np.array([0, 0])
+    expected = np.array([0, 0, 0, 0, -1, -1, -1, -1])
     assert np.array_equal(result, expected)
 
 

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -190,6 +190,7 @@ def test_triangle_lookup__tolerance():
     result = tree.locate_points(point, tolerance=1e-9)
     expected = np.array([-1, 1, -1])
     assert np.array_equal(result, expected)
+    # TODO: Set tolerance to 1e-1 when tolerance is actually a distance.
     result = tree.locate_points(point, tolerance=2e-1)
     expected = np.array([0, 1, -1])
     assert np.array_equal(result, expected)
@@ -289,6 +290,21 @@ def test_multi_poly_lookup():
     )
     result = tree.locate_points(point)
     expected = np.array([0, 2, 1, -1])
+    assert np.array_equal(result, expected)
+
+    # Test with a point that is very close to the edge of a cell
+    point = np.array(
+        [
+            [-1e-8, 1.0],
+            [1.0, -1e-8],
+        ]
+    )
+    result = tree.locate_points(point)
+    expected = np.array([-1, -1])
+    assert np.array_equal(result, expected)
+    # TODO: Set tolerance to 1e-8 when tolerance is actually a distance.
+    result = tree.locate_points(point, tolerance=5e-8)
+    expected = np.array([0, 0])
     assert np.array_equal(result, expected)
 
 

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -704,4 +704,12 @@ def test_locate_point_on_edge():
             [4.0, 4.0],
         ]
     )
+    result = tree.locate_points(points)
+    assert (result != -1).all()
+    # Test tolerance check for points on the edge of a cell
+    points[points == 0.0] = -1e-9
+    points[points == 4.0] = 4.0 + 1e-9
+    result = tree.locate_points(points)
+    assert not (result != -1).all()
+    result = tree.locate_points(points, tolerance=1.1e-9)
     assert (result != -1).all()

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -182,7 +182,7 @@ def test_triangle_lookup__tolerance():
     tree = CellTree2d(nodes, faces, fill_value)
     point = np.array(
         [
-            [-0.1, 0.0],
+            [-0.09, 0.0],
             [2.0, 1.0],
             [-1.0, 1.0],
         ]

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -178,6 +178,23 @@ def test_triangle_lookup():
     assert np.array_equal(result, expected)
 
 
+def test_triangle_lookup__tolerance():
+    tree = CellTree2d(nodes, faces, fill_value)
+    point = np.array(
+        [
+            [-0.1, 0.0],
+            [2.0, 1.0],
+            [-1.0, 1.0],
+        ]
+    )  # in triangle 1
+    result = tree.locate_points(point, tolerance=1e-9)
+    expected = np.array([-1, 1, -1])
+    assert np.array_equal(result, expected)
+    result = tree.locate_points(point, tolerance=2e-1)
+    expected = np.array([0, 1, -1])
+    assert np.array_equal(result, expected)
+
+
 def test_poly_lookup():
     # A simple quad grid
     nodes = np.array(

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -190,8 +190,7 @@ def test_triangle_lookup__tolerance():
     result = tree.locate_points(point, tolerance=1e-9)
     expected = np.array([-1, 1, -1])
     assert np.array_equal(result, expected)
-    # TODO: Set tolerance to 1e-1 when tolerance is actually a distance.
-    result = tree.locate_points(point, tolerance=2e-1)
+    result = tree.locate_points(point, tolerance=1e-1)
     expected = np.array([0, 1, -1])
     assert np.array_equal(result, expected)
 

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -300,11 +300,9 @@ def test_multi_poly_lookup():
             [1.0, -9e-9],  # On edge
             [-1.1e-8, 1.0],  # Outside, very close to edge
             [1.0, -1.1e-8],  # Outside, very close to edge
-            [-1.1e-8, 0.0],  # Outside, very close to vertex
-            [
-                2.0,
-                -1.5e-8,
-            ],  # Outside, very close to vertex (for some reason y = -1.1e-8 is still considered inside)
+            [-1.1e-8, 0.0],  # Outside, very close to vertex'
+            # Outside, very close to vertex (for some reason y = -1.1e-8 is still considered inside)
+            [2.0, -1.5e-8],
         ]
     )
     result = tree.locate_points(point)

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -294,15 +294,14 @@ def test_multi_poly_lookup():
     # Test with a point that is very close to the edge of a cell
     point = np.array(
         [
-            [-1e-8, 1.0],
-            [1.0, -1e-8],
+            [-9e-9, 1.0],
+            [1.0, -9e-9],
         ]
     )
     result = tree.locate_points(point)
     expected = np.array([-1, -1])
     assert np.array_equal(result, expected)
-    # TODO: Set tolerance to 1e-8 when tolerance is actually a distance.
-    result = tree.locate_points(point, tolerance=5e-8)
+    result = tree.locate_points(point, tolerance=1e-8)
     expected = np.array([0, 0])
     assert np.array_equal(result, expected)
 

--- a/tests/test_celltree_utils.py
+++ b/tests/test_celltree_utils.py
@@ -1,0 +1,46 @@
+from numba_celltree.constants import TOLERANCE_FACTOR, MIN_TOLERANCE
+from numba_celltree.celltree_base import default_tolerance, bbox_tree, bbox_distances
+import numpy as np
+
+bbox_coords = np.array(
+    [
+        [1.0, 2.0, 1.0, 2.0],
+        [4.0, 5.0, 0.0, 1.0],
+        [4.0, 5.0, 2.0, 3.0],
+        [-1.0, 0.0, 0.0, 4.0],
+        [6.0, 8.0, 0.0, 4.0],
+        [0.0, 6.0, -1.0, 0.0],
+        [0.0, 6.0, 4.0, 5.0],
+    ]
+)
+
+def test_default_tolerance():
+    bb_diagonal = np.array([2.4, 0.5])
+    tolerance = default_tolerance(bb_diagonal)
+    expected_value = 2.4 * TOLERANCE_FACTOR
+    np.testing.assert_allclose(tolerance, expected_value, rtol=0, atol=MIN_TOLERANCE/1e5)
+
+    tolerance = default_tolerance(bb_diagonal/1e4)
+    np.testing.assert_allclose(tolerance, MIN_TOLERANCE, rtol=0, atol=MIN_TOLERANCE/1e5)
+
+
+def test_bbox_tree():
+    expected_bbox = np.array([-1.0, 8.0, -1.0, 5.0])
+    bbox = bbox_tree(bbox_coords)
+    np.testing.assert_allclose(bbox, expected_bbox, rtol=0, atol=1e-5)
+
+
+def test_bbox_distances():
+    expected_distances = np.array(
+        [
+            [1.0, 1.0, 1.41421356],
+            [1.0, 1.0, 1.41421356],
+            [1.0, 1.0, 1.41421356],
+            [1.0, 4.0, 4.12310563],
+            [2.0, 4.0, 4.47213595],
+            [6.0, 1.0, 6.08276253],
+            [6.0, 1.0, 6.08276253],
+        ]
+    )
+    distances = bbox_distances(bbox_coords)
+    np.testing.assert_allclose(distances, expected_distances, rtol=0, atol=1e-5)

--- a/tests/test_celltree_utils.py
+++ b/tests/test_celltree_utils.py
@@ -1,6 +1,7 @@
-from numba_celltree.constants import TOLERANCE_FACTOR, MIN_TOLERANCE
-from numba_celltree.celltree_base import default_tolerance, bbox_tree, bbox_distances
 import numpy as np
+
+from numba_celltree.celltree_base import bbox_distances, bbox_tree, default_tolerance
+from numba_celltree.constants import MIN_TOLERANCE, TOLERANCE_FACTOR
 
 bbox_coords = np.array(
     [
@@ -14,14 +15,19 @@ bbox_coords = np.array(
     ]
 )
 
+
 def test_default_tolerance():
     bb_diagonal = np.array([2.4, 0.5])
     tolerance = default_tolerance(bb_diagonal)
     expected_value = 2.4 * TOLERANCE_FACTOR
-    np.testing.assert_allclose(tolerance, expected_value, rtol=0, atol=MIN_TOLERANCE/1e5)
+    np.testing.assert_allclose(
+        tolerance, expected_value, rtol=0, atol=MIN_TOLERANCE / 1e5
+    )
 
-    tolerance = default_tolerance(bb_diagonal/1e4)
-    np.testing.assert_allclose(tolerance, MIN_TOLERANCE, rtol=0, atol=MIN_TOLERANCE/1e5)
+    tolerance = default_tolerance(bb_diagonal / 1e4)
+    np.testing.assert_allclose(
+        tolerance, MIN_TOLERANCE, rtol=0, atol=MIN_TOLERANCE / 1e5
+    )
 
 
 def test_bbox_tree():

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -52,6 +52,20 @@ def test_locate_points():
     )
 
 
+def test_locate_points_big_coords__tolerance():
+    vertices = np.array(
+        [[171805.657000002, 563516.366], [171889.594000001, 563437.333000001]]
+    )
+    edges = np.array([[0, 1]])
+    tree = EdgeCellTree2d(vertices, edges)
+    points = np.array([[171882.49385095935, 563444.0183244612]])
+    tree_edge_indices = tree.locate_points(points, tolerance=1e-8)
+    np.testing.assert_array_equal(tree_edge_indices, np.array([0], dtype=np.int32))
+    # test with a tolerance that is too small
+    tree_edge_indices = tree.locate_points(points, tolerance=1e-9)
+    np.testing.assert_array_equal(tree_edge_indices, np.array([-1], dtype=np.int32))
+
+
 def test_intersect_edges():
     tree = EdgeCellTree2d(vertices, edges)
     edge_coords = np.array(

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -142,3 +142,32 @@ def test_intersect_edges__tolerance():
     np.testing.assert_array_equal(actual_edge, expected_edge)
     np.testing.assert_array_equal(actual_tree_edge, expected_tree_edge)
     np.testing.assert_allclose(actual_xy, expected_xy, atol=big_tol)
+
+
+
+def test_intersect_edges__tolerance2():
+    """Test case with two separate parallel edges, of length 1.0"""
+    vertices = np.array([[0.0, 100.0], [0.0, 101.0], [10.0, 100.0], [10.0, 101.0]], dtype=float)
+    edges = np.array([[0, 1], [2, 3]], dtype=np.int32)
+    big_tol = 0.5
+
+    tree = EdgeCellTree2d(vertices, edges, tolerance=big_tol, cells_per_leaf=1)
+    edge_coords = np.array(
+        [
+            [[8.0, 100.5], [10.0-(big_tol/2), 100.5]],  # 0 intersects both edges
+        ]
+    )
+    actual_edge, actual_tree_edge, actual_xy = tree.intersect_edges(
+        edge_coords, big_tol
+    )
+    expected_edge = np.array([0], dtype=np.int32)
+    expected_tree_edge = np.array([1], dtype=np.int32)
+    expected_xy = np.array(
+        [
+            [10.0, 100.5],
+        ],
+        dtype=float,
+    )
+    np.testing.assert_array_equal(actual_edge, expected_edge)
+    np.testing.assert_array_equal(actual_tree_edge, expected_tree_edge)
+    np.testing.assert_allclose(actual_xy, expected_xy, atol=big_tol)

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -37,30 +37,6 @@ def test_init():
     )
 
 
-def test_init__tolerance():
-    """
-    Initialize with very large tolerance, test if this creates large bbox
-    coords.
-    """
-    big_tol = 0.5
-    tree = EdgeCellTree2d(vertices, edges, tolerance=big_tol)
-
-    expected_bb_coords = np.array(
-        [
-            [-0.5, 1.5, -0.5, 0.5],
-            [0.5, 2.5, -0.5, 0.5],
-            [1.5, 2.5, -0.5, 1.5],
-        ],
-        dtype=float,
-    )
-    np.testing.assert_allclose(
-        tree.bb_coords, expected_bb_coords, atol=TOLERANCE_ON_EDGE
-    )
-    np.testing.assert_allclose(
-        tree.bbox, np.array([-0.5, 2.5, -0.5, 1.5]), atol=TOLERANCE_ON_EDGE
-    )
-
-
 def test_locate_points():
     tree = EdgeCellTree2d(vertices, edges)
     points = np.array([[0.5, 0.0], [1.5, 0.0], [2.0, 0.5]], dtype=float)

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -95,80 +95,20 @@ def test_intersect_edges():
     tree = EdgeCellTree2d(vertices, edges)
     edge_coords = np.array(
         [
-            [[1.0, -1.0], [1.0, 1.0]],  # 0 orthogonal
+            [[1.0, -1.0], [1.0, 1.0]],  # 0 orthogonal, on vertex
             [[3.0, 1.0], [-1.0, -1.0]],  # 1 two intersctions
             [[0.0, -1.0], [0.0, 1.0]],  # 2 on start vertex tree
             [[-2.0, -1.0], [-3.0, -1.0]],  # no interesect
         ]
     )
     actual_edge, actual_tree_edge, actual_xy = tree.intersect_edges(edge_coords)
-    expected_edge = np.array([0, 1, 1, 2], dtype=np.int32)
-    expected_tree_edge = np.array([1, 1, 2, 0], dtype=np.int32)
+    expected_edge = np.array([0, 0, 1, 1, 2], dtype=np.int32)
+    expected_tree_edge = np.array([1, 0, 1, 2, 0], dtype=np.int32)
     expected_xy = np.array(
-        [[1.0, 0.0], [1.0, 0.0], [2.0, 0.5], [0.0, 0.0]], dtype=float
+        [[1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [2.0, 0.5], [0.0, 0.0]], dtype=float
     )
 
     np.testing.assert_array_equal(actual_edge, expected_edge)
     np.testing.assert_array_equal(actual_tree_edge, expected_tree_edge)
     np.testing.assert_allclose(actual_xy, expected_xy, atol=TOLERANCE_ON_EDGE)
 
-
-def test_intersect_edges__tolerance():
-    tree = EdgeCellTree2d(vertices, edges)
-    edge_coords = np.array(
-        [
-            [[-0.009, -1.0], [-0.009, 1.0]],  # 0 just left of start vertex tree
-            [[-2.0, -1.0], [-3.0, -1.0]],  # no interesect
-        ]
-    )
-    actual_edge, actual_tree_edge, actual_xy = tree.intersect_edges(edge_coords)
-    assert actual_edge.size == 0
-    assert actual_tree_edge.size == 0
-    assert actual_xy.size == 0
-
-    big_tol = 1e-2
-    tree = EdgeCellTree2d(vertices, edges, tolerance=big_tol)
-    actual_edge, actual_tree_edge, actual_xy = tree.intersect_edges(
-        edge_coords, big_tol
-    )
-    expected_edge = np.array([0], dtype=np.int32)
-    expected_tree_edge = np.array([0], dtype=np.int32)
-    expected_xy = np.array(
-        [
-            [0.0, 0.0],
-        ],
-        dtype=float,
-    )
-    np.testing.assert_array_equal(actual_edge, expected_edge)
-    np.testing.assert_array_equal(actual_tree_edge, expected_tree_edge)
-    np.testing.assert_allclose(actual_xy, expected_xy, atol=big_tol)
-
-
-def test_intersect_edges__tolerance2():
-    """Test case with two separate parallel edges, of length 1.0"""
-    vertices = np.array(
-        [[0.0, 100.0], [0.0, 101.0], [10.0, 100.0], [10.0, 101.0]], dtype=float
-    )
-    edges = np.array([[0, 1], [2, 3]], dtype=np.int32)
-    big_tol = 0.5
-
-    tree = EdgeCellTree2d(vertices, edges, tolerance=big_tol, cells_per_leaf=1)
-    edge_coords = np.array(
-        [
-            [[8.0, 100.5], [10.0 - (big_tol / 2), 100.5]],  # 0 intersects both edges
-        ]
-    )
-    actual_edge, actual_tree_edge, actual_xy = tree.intersect_edges(
-        edge_coords, big_tol
-    )
-    expected_edge = np.array([0], dtype=np.int32)
-    expected_tree_edge = np.array([1], dtype=np.int32)
-    expected_xy = np.array(
-        [
-            [10.0, 100.5],
-        ],
-        dtype=float,
-    )
-    np.testing.assert_array_equal(actual_edge, expected_edge)
-    np.testing.assert_array_equal(actual_tree_edge, expected_tree_edge)
-    np.testing.assert_allclose(actual_xy, expected_xy, atol=big_tol)

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -1,7 +1,9 @@
 import numpy as np
 
 from numba_celltree import EdgeCellTree2d
-from numba_celltree.constants import TOLERANCE_ON_EDGE, CellTreeData
+from numba_celltree.constants import CellTreeData
+
+TOLERANCE_ON_EDGE = 1e-9
 
 vertices = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [2.0, 1.0]], dtype=float)
 edges = np.array([[0, 1], [1, 2], [2, 3]], dtype=np.int32)

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -37,6 +37,30 @@ def test_init():
     )
 
 
+def test_init__tolerance():
+    """
+    Initialize with very large tolerance, test if this creates large bbox
+    coords.
+    """
+    big_tol = 0.5
+    tree = EdgeCellTree2d(vertices, edges, tolerance=big_tol)
+
+    expected_bb_coords = np.array(
+        [
+            [-0.5, 1.5, -0.5, 0.5],
+            [0.5, 2.5, -0.5, 0.5],
+            [1.5, 2.5, -0.5, 1.5],
+        ],
+        dtype=float,
+    )
+    np.testing.assert_allclose(
+        tree.bb_coords, expected_bb_coords, atol=TOLERANCE_ON_EDGE
+    )
+    np.testing.assert_allclose(
+        tree.bbox, np.array([-0.5, 2.5, -0.5, 1.5]), atol=TOLERANCE_ON_EDGE
+    )
+
+
 def test_locate_points():
     tree = EdgeCellTree2d(vertices, edges)
     points = np.array([[0.5, 0.0], [1.5, 0.0], [2.0, 0.5]], dtype=float)

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -144,17 +144,18 @@ def test_intersect_edges__tolerance():
     np.testing.assert_allclose(actual_xy, expected_xy, atol=big_tol)
 
 
-
 def test_intersect_edges__tolerance2():
     """Test case with two separate parallel edges, of length 1.0"""
-    vertices = np.array([[0.0, 100.0], [0.0, 101.0], [10.0, 100.0], [10.0, 101.0]], dtype=float)
+    vertices = np.array(
+        [[0.0, 100.0], [0.0, 101.0], [10.0, 100.0], [10.0, 101.0]], dtype=float
+    )
     edges = np.array([[0, 1], [2, 3]], dtype=np.int32)
     big_tol = 0.5
 
     tree = EdgeCellTree2d(vertices, edges, tolerance=big_tol, cells_per_leaf=1)
     edge_coords = np.array(
         [
-            [[8.0, 100.5], [10.0-(big_tol/2), 100.5]],  # 0 intersects both edges
+            [[8.0, 100.5], [10.0 - (big_tol / 2), 100.5]],  # 0 intersects both edges
         ]
     )
     actual_edge, actual_tree_edge, actual_xy = tree.intersect_edges(

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -88,7 +88,7 @@ def test_locate_points_big_coords__tolerance():
     np.testing.assert_array_equal(tree_edge_indices, np.array([0], dtype=np.int32))
     # test with a tolerance that is too small
     tree_edge_indices = tree.locate_points(points, tolerance=1e-9)
-    np.testing.assert_array_equal(tree_edge_indices, np.array([-1], dtype=np.int32))
+    np.testing.assert_array_equal(tree_edge_indices, np.array([0], dtype=np.int32))
 
 
 def test_intersect_edges():

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -111,4 +111,3 @@ def test_intersect_edges():
     np.testing.assert_array_equal(actual_edge, expected_edge)
     np.testing.assert_array_equal(actual_tree_edge, expected_tree_edge)
     np.testing.assert_allclose(actual_xy, expected_xy, atol=TOLERANCE_ON_EDGE)
-

--- a/tests/test_edgecelltree.py
+++ b/tests/test_edgecelltree.py
@@ -53,6 +53,7 @@ def test_locate_points():
 
 
 def test_locate_points_big_coords__tolerance():
+    """Small test case extracted from LHM"""
     vertices = np.array(
         [[171805.657000002, 563516.366], [171889.594000001, 563437.333000001]]
     )
@@ -86,3 +87,34 @@ def test_intersect_edges():
     np.testing.assert_array_equal(actual_edge, expected_edge)
     np.testing.assert_array_equal(actual_tree_edge, expected_tree_edge)
     np.testing.assert_allclose(actual_xy, expected_xy, atol=TOLERANCE_ON_EDGE)
+
+
+def test_intersect_edges__tolerance():
+    tree = EdgeCellTree2d(vertices, edges)
+    edge_coords = np.array(
+        [
+            [[-0.009, -1.0], [-0.009, 1.0]],  # 0 just left of start vertex tree
+            [[-2.0, -1.0], [-3.0, -1.0]],  # no interesect
+        ]
+    )
+    actual_edge, actual_tree_edge, actual_xy = tree.intersect_edges(edge_coords)
+    assert actual_edge.size == 0
+    assert actual_tree_edge.size == 0
+    assert actual_xy.size == 0
+
+    big_tol = 1e-2
+    tree = EdgeCellTree2d(vertices, edges, tolerance=big_tol)
+    actual_edge, actual_tree_edge, actual_xy = tree.intersect_edges(
+        edge_coords, big_tol
+    )
+    expected_edge = np.array([0], dtype=np.int32)
+    expected_tree_edge = np.array([0], dtype=np.int32)
+    expected_xy = np.array(
+        [
+            [0.0, 0.0],
+        ],
+        dtype=float,
+    )
+    np.testing.assert_array_equal(actual_edge, expected_edge)
+    np.testing.assert_array_equal(actual_tree_edge, expected_tree_edge)
+    np.testing.assert_allclose(actual_xy, expected_xy, atol=big_tol)

--- a/tests/test_geometry_utils.py
+++ b/tests/test_geometry_utils.py
@@ -8,6 +8,7 @@ from numba_celltree import geometry_utils as gu
 from numba_celltree.constants import TOLERANCE_ON_EDGE, Box, Point, Triangle, Vector
 
 
+
 def test_to_vector():
     a = Point(0.0, 0.0)
     b = Point(1.0, 2.0)
@@ -349,13 +350,6 @@ class IntersectCases:
         return p, q, expected_intersects, expected_intersection_point
 
     def case_vertex_on_edge(self):
-        p = Point(3.0, 3.0)
-        q = Point(3.0, 1.0)
-        expected_intersects = True
-        expected_intersection_point = Point(3.0, 3.0)
-        return p, q, expected_intersects, expected_intersection_point
-
-    def case_vertex_on_edge2(self):
         p = Point(-1.0, 1.0)
         q = Point(1.0, -1.0)
         expected_intersects = True
@@ -374,13 +368,6 @@ class IntersectCases:
         q = Point(3.0, 1.0)
         expected_intersects = True
         expected_intersection_point = Point(2.0, 2.0)
-        return p, q, expected_intersects, expected_intersection_point
-
-    def case_vertex_on_vertex(self):
-        p = Point(0.0, 0.0)
-        q = Point(1.0, -1.0)
-        expected_intersects = True
-        expected_intersection_point = Point(0.0, 0.0)
         return p, q, expected_intersects, expected_intersection_point
 
     def case_vertex_on_vertex_collinear(self):
@@ -404,12 +391,12 @@ class IntersectCases:
 def test_lines_intersect(p, q, expected_intersects, expected_intersection_point):
     a = Point(0.0, 0.0)
     b = Point(4.0, 4.0)
-    actual_intersects, x, y = gu.lines_intersect(a, b, p, q, TOLERANCE_ON_EDGE)
+    actual_intersects, x, y = gu.lines_intersect(a, b, p, q)
     assert actual_intersects == expected_intersects
     np.testing.assert_allclose(x, expected_intersection_point.x)
     np.testing.assert_allclose(y, expected_intersection_point.y)
     # Reverse order edges
-    actual_intersects, x, y = gu.lines_intersect(p, q, a, b, TOLERANCE_ON_EDGE)
+    actual_intersects, x, y = gu.lines_intersect(p, q, a, b)
     assert actual_intersects == expected_intersects
     np.testing.assert_allclose(x, expected_intersection_point.x)
     np.testing.assert_allclose(y, expected_intersection_point.y)

--- a/tests/test_geometry_utils.py
+++ b/tests/test_geometry_utils.py
@@ -404,12 +404,12 @@ class IntersectCases:
 def test_lines_intersect(p, q, expected_intersects, expected_intersection_point):
     a = Point(0.0, 0.0)
     b = Point(4.0, 4.0)
-    actual_intersects, x, y = gu.lines_intersect(a, b, p, q)
+    actual_intersects, x, y = gu.lines_intersect(a, b, p, q, TOLERANCE_ON_EDGE)
     assert actual_intersects == expected_intersects
     np.testing.assert_allclose(x, expected_intersection_point.x)
     np.testing.assert_allclose(y, expected_intersection_point.y)
     # Reverse order edges
-    actual_intersects, x, y = gu.lines_intersect(p, q, a, b)
+    actual_intersects, x, y = gu.lines_intersect(p, q, a, b, TOLERANCE_ON_EDGE)
     assert actual_intersects == expected_intersects
     np.testing.assert_allclose(x, expected_intersection_point.x)
     np.testing.assert_allclose(y, expected_intersection_point.y)

--- a/tests/test_geometry_utils.py
+++ b/tests/test_geometry_utils.py
@@ -216,6 +216,35 @@ def test_build_face_bboxes():
     assert np.array_equal(actual, expected)
 
 
+def test_build_edge_bboxes():
+    vertices = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [2.0, 1.0]], dtype=float)
+    edges = np.array([[0, 1], [1, 2], [2, 3]], dtype=np.int32)
+
+    bb_coords = gu.build_edge_bboxes(edges, vertices, 0.0)
+    expected_bb_coords = np.array(
+        [
+            [0.0, 1.0, 0.0, 0.0],
+            [1.0, 2.0, 0.0, 0.0],
+            [2.0, 2.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+    np.testing.assert_allclose(bb_coords, expected_bb_coords, atol=TOLERANCE_ON_EDGE)
+    # Test if tolerance is properly accounted for by providing a large
+    # tolerance.
+    big_tol = 0.5
+    bb_coords = gu.build_edge_bboxes(edges, vertices, big_tol)
+    expected_bb_coords = np.array(
+        [
+            [-0.5, 1.5, -0.5, 0.5],
+            [0.5, 2.5, -0.5, 0.5],
+            [1.5, 2.5, -0.5, 1.5],
+        ],
+        dtype=float,
+    )
+    np.testing.assert_allclose(bb_coords, expected_bb_coords, atol=TOLERANCE_ON_EDGE)
+
+
 def test_copy_vertices():
     """
     This has to be tested inside of numba jitted function, because the vertices

--- a/tests/test_geometry_utils.py
+++ b/tests/test_geometry_utils.py
@@ -8,7 +8,6 @@ from numba_celltree import geometry_utils as gu
 from numba_celltree.constants import TOLERANCE_ON_EDGE, Box, Point, Triangle, Vector
 
 
-
 def test_to_vector():
     a = Point(0.0, 0.0)
     b = Point(1.0, 2.0)

--- a/tests/test_geometry_utils.py
+++ b/tests/test_geometry_utils.py
@@ -5,7 +5,9 @@ import numpy as np
 from pytest_cases import parametrize_with_cases
 
 from numba_celltree import geometry_utils as gu
-from numba_celltree.constants import TOLERANCE_ON_EDGE, Box, Point, Triangle, Vector
+from numba_celltree.constants import Box, Point, Triangle, Vector
+
+TOLERANCE_ON_EDGE = 1e-9
 
 
 def test_to_vector():
@@ -220,25 +222,12 @@ def test_build_edge_bboxes():
     vertices = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [2.0, 1.0]], dtype=float)
     edges = np.array([[0, 1], [1, 2], [2, 3]], dtype=np.int32)
 
-    bb_coords = gu.build_edge_bboxes(edges, vertices, 0.0)
+    bb_coords = gu.build_edge_bboxes(edges, vertices)
     expected_bb_coords = np.array(
         [
             [0.0, 1.0, 0.0, 0.0],
             [1.0, 2.0, 0.0, 0.0],
             [2.0, 2.0, 0.0, 1.0],
-        ],
-        dtype=float,
-    )
-    np.testing.assert_allclose(bb_coords, expected_bb_coords, atol=TOLERANCE_ON_EDGE)
-    # Test if tolerance is properly accounted for by providing a large
-    # tolerance.
-    big_tol = 0.5
-    bb_coords = gu.build_edge_bboxes(edges, vertices, big_tol)
-    expected_bb_coords = np.array(
-        [
-            [-0.5, 1.5, -0.5, 0.5],
-            [0.5, 2.5, -0.5, 0.5],
-            [1.5, 2.5, -0.5, 1.5],
         ],
         dtype=float,
     )


### PR DESCRIPTION
Fixes https://github.com/Deltares/numba_celltree/issues/41

Adds ``tolerance`` as argument, to make tolerance configurable. I ran into problems with the HYDAMO dataset, as projected coords are large, which lead to precision errors. I think making tolerance configurable by the user is a neat feature to have.
