### PR TITLE
Ensure that remaining elements are assigned to the final bucket

### DIFF
--- a/numba_celltree/creation.py
+++ b/numba_celltree/creation.py
@@ -122,32 +122,41 @@ def sort_bbox_indices(
 ):
     current = node.ptr
     end = node.ptr + node.size
+    n = len(buckets)
 
-    b = buckets[0]
-    buckets[0] = Bucket(b.Max, b.Min, b.Rmin, b.Lmax, node.ptr, b.size)
-
-    i = 1
-    while current != end:
-        bucket = buckets[i - 1]
-        current = stable_partition(bb_indices, bb_coords, current, end, bucket, dim)
-        start = bucket.index
-
-        b = buckets[i - 1]
-        buckets[i - 1] = Bucket(b.Max, b.Min, b.Rmin, b.Lmax, b.index, current - start)
-
-        if i < len(buckets):
-            b = buckets[i]
-            buckets[i] = Bucket(
-                b.Max,
-                b.Min,
-                b.Rmin,
-                b.Lmax,
-                buckets[i - 1].index + buckets[i - 1].size,
-                b.size,
-            )
-
+    # Explicitly partition into the first n - 1 buckets.
+    for i in range(n - 1):
         start = current
-        i += 1
+        bucket = buckets[i]
+
+        current = stable_partition(
+            bb_indices,
+            bb_coords,
+            current,
+            end,
+            bucket,
+            dim,
+        )
+
+        buckets[i] = Bucket(
+            bucket.Max,
+            bucket.Min,
+            bucket.Rmin,
+            bucket.Lmax,
+            start,
+            current - start,
+        )
+
+    # Everything not matched earlier belongs to the final bucket.
+    bucket = buckets[n - 1]
+    buckets[n - 1] = Bucket(
+        bucket.Max,
+        bucket.Min,
+        bucket.Rmin,
+        bucket.Lmax,
+        current,
+        end - current,
+    )
 
 
 @nb.njit(inline="never", cache=True)

--- a/tests/test_celltree.py
+++ b/tests/test_celltree.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from numba_celltree import CellTree2d, demo
+from numba_celltree.creation import initialize
 
 
 @pytest.fixture
@@ -110,6 +111,37 @@ def test_init_larger_mesh(datadir):
     nodes = np.loadtxt(datadir / "xy.txt", dtype=float)
     faces = np.loadtxt(datadir / "triangles.txt", dtype=int)
     CellTree2d(nodes, faces, fill_value, n_buckets=2)
+
+
+def test_three_boxes_cover_final_bucket_endpoint():
+    x_min = np.float64(131_072.0)
+    x_max = np.float64(262_144.0)
+
+    boxes = np.array(
+        [
+            [x_min, np.nextafter(x_min, np.inf), 0.0, 1.0],
+            [196_000.0, 196_001.0, 0.0, 1.0],
+            [np.nextafter(x_max, -np.inf), x_max, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+
+    special_midpoint = boxes[-1, 0] + 0.5 * (boxes[-1, 1] - boxes[-1, 0])
+    assert special_midpoint == x_max
+
+    elements = np.zeros((len(boxes), 3), dtype=np.int64)
+
+    _, permutation = initialize(
+        elements,
+        boxes,
+        n_buckets=4,
+        cells_per_leaf=2,
+    )
+
+    np.testing.assert_array_equal(
+        np.sort(permutation),
+        np.arange(len(boxes), dtype=permutation.dtype),
+    )
 
 
 def test_lists():


### PR DESCRIPTION
When the bounding box is only 1 ULP wide, the centroid is identical to xmin or xmax in floating point arithmetic. In the case of centroid==xmax, the centroid may not fall left of the maximum.

Fixes #89